### PR TITLE
Fix: Pip install fails when paramiko is in requirements list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 from setuptools import setup
 
+__version_info__ = (0, 0, 1)
+__version__ = '.'.join(str(i) for i in __version_info__)
 __author__ = 'pahaz'
 
 appname = 'sshtunnel'
-app = __import__(appname)
-version = app.__version__
 
 setup(
     name=appname,
-    version=version,
+    version=__version__,
     description="Initiate SSH tunnels",
     long_description=open('README.md').read(),
     py_modules=[appname],
@@ -16,7 +16,7 @@ setup(
     author='Pahaz Blinov',
     author_email='pahaz.blinov@gmail.com',
     url='https://github.com/pahaz/sshtunnel',
-    download_url='https://github.com/pahaz/sshtunnel/tarball/' + version,
+    download_url='https://github.com/pahaz/sshtunnel/tarball/' + __version__,
     keywords=['SSH', 'proxy', 'TCP forwarder'],
     license='MIT',
     platforms=['unix', 'macos', 'windows'],


### PR DESCRIPTION
First off, thanks for the sshtunnel script.

Problem: The pip installer fails when using a requirements file that also includes paramiko.

requirements.txt
```
pycrypto==2.6.1
paramiko==1.15.2
sshtunnel==0.0.1
```

```bash
pip install -r requirements.txt
```

The reason that pip fails is because the setup.py file currently includes the actual sshtunnel.py file, which then includes paramiko (before it is installed). Despite the fact that paramiko is required, it should not be required in the setup.py file.

The two solutions for this are (1) to add a try catch to including paramiko to allow the file to be imported without error into the setup.py file, or (2) to have redundant version information that eliminates the need to import the sshtunnel.py file. Despite my dislike for redundancy, I'm suggesting solution (2), since importing the actual module in setup.py does not keep seperation between the installer and the actual script.

Please push a new version to PyPI once this is fixed so that sshtunnel can be successfully distributed in requirements.txt files.