### PR TITLE
sshtunnel 0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ __pycache__/
 # due to using tox and pytest
 .tox
 .cache
+.coverage
+pytestdebug.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2015 Pahaz Blinov
+Copyright (c) 2014-2016 Pahaz Blinov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -126,7 +126,7 @@ See either the |paramiko.ProxyCommand|_ documentation
 or ``ProxyCommand`` in ``ssh_config(5)`` for more information.
 
  Note: ``ssh_proxy`` overrides any ``ProxyCommand`` sourced from the user
-``ssh_config``.
+ ``ssh_config``.
 
  Note: ``ssh_proxy`` is ignored if ``ssh_proxy_enabled != True``.
 

--- a/README.rst
+++ b/README.rst
@@ -159,9 +159,9 @@ CHANGELOG
 =========
 
 - v.0.0.7
-    + Tunnels can now be stopped and started safely (\#41_)
-    + Add timeout to SSH gateway and keep-alive messages (\#29_)
-    + Allow sending a pkey directly (\#43_)
+    + Tunnels can now be stopped and started safely (:ref:`#41`)
+    + Add timeout to SSH gateway and keep-alive messages (:ref:`#29`)
+    + Allow sending a pkey directly (:ref:`#43`)
     + Add ``-V`` CLI option to show current version
     + Refactoring
 
@@ -262,16 +262,16 @@ HELP
 .. |paramiko.ProxyCommand| replace:: ``paramiko.ProxyCommand``
 .. _paramiko.ProxyCommand: http://paramiko-docs.readthedocs.org/en/latest/api/proxy.html
 
-.. _\#13: https://github.com/pahaz/sshtunnel/issues/13
-.. _\#16: https://github.com/pahaz/sshtunnel/issues/16
-.. _\#19: https://github.com/pahaz/sshtunnel/issues/19
-.. _\#21: https://github.com/pahaz/sshtunnel/issues/21
-.. _\#24: https://github.com/pahaz/sshtunnel/issues/24
-.. _\#29: https://github.com/pahaz/sshtunnel/issues/29
-.. _\#33: https://github.com/pahaz/sshtunnel/issues/33
-.. _\#34: https://github.com/pahaz/sshtunnel/issues/34
-.. _\#41: https://github.com/pahaz/sshtunnel/issues/41
-.. _\#43: https://github.com/pahaz/sshtunnel/issues/43
+.. _#13: https://github.com/pahaz/sshtunnel/issues/13
+.. _#16: https://github.com/pahaz/sshtunnel/issues/16
+.. _#19: https://github.com/pahaz/sshtunnel/issues/19
+.. _#21: https://github.com/pahaz/sshtunnel/issues/21
+.. _#24: https://github.com/pahaz/sshtunnel/issues/24
+.. _#29: https://github.com/pahaz/sshtunnel/issues/29
+.. _#33: https://github.com/pahaz/sshtunnel/issues/33
+.. _#34: https://github.com/pahaz/sshtunnel/issues/34
+.. _#41: https://github.com/pahaz/sshtunnel/issues/41
+.. _#43: https://github.com/pahaz/sshtunnel/issues/43
 .. _detail: https://github.com/pahaz/sshtunnel/commit/64af238b799b0e0057c4f9b386cda247e0006da9#diff-76bc1662a114401c2954deb92b740081R127
 
 .. |CircleCI| image:: https://circleci.com/gh/pahaz/sshtunnel.svg?style=svg

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ calling the `close` method of the returned SSHTunnelForwarder object.::
 
     ----------------------------------------------------------------------
 
-Fig1: How to connect to PRIVATE SERVER through SSH tunnel.
+**Fig1**: How to connect to ``PRIVATE SERVER`` through SSH tunnel.
 
 
 Example 1
@@ -70,7 +70,8 @@ Example 1
         ('pahaz.urfuclub.ru', 22),
         ssh_username="pahaz",
         ssh_password="secret",
-        remote_bind_address=('127.0.0.1', 5555))
+        remote_bind_address=('127.0.0.1', 5555)
+    )
 
     server.start()
 
@@ -93,7 +94,8 @@ Example of a port forwarding for the Vagrant MySQL local port:
         ('localhost', 2222),
         ssh_username="vagrant",
         ssh_password="vagrant",
-        remote_bind_address=('127.0.0.1', 3306)) as server:
+        remote_bind_address=('127.0.0.1', 3306)
+    ) as server:
 
         print(server.local_bind_port)
         while True:
@@ -157,9 +159,9 @@ CHANGELOG
 =========
 
 - v.0.0.7
-    + Tunnels can now be stopped and started safely (#41_)
-    + Add timeout to SSH gateway and keep-alive messages (#29_)
-    + Allow sending a pkey directly (#43_)
+    + Tunnels can now be stopped and started safely (\#41_)
+    + Add timeout to SSH gateway and keep-alive messages (\#29_)
+    + Allow sending a pkey directly (\#43_)
     + Add ``-V`` CLI option to show current version
     + Refactoring
 
@@ -170,7 +172,7 @@ CHANGELOG
     + add ``ssh_proxy`` argument, as well as ``ssh_config(5)`` ``ProxyCommand`` support (lewisthompson)
     + add some python 2.6 compatibility fixes (mrts)
     + ``paramiko.transport`` inherits handlers of loggers passed to ``SSHTunnelForwarder`` (fernandezcuesta)
-    + fix #34_, #33_, code style and docs (fernandezcuesta)
+    + fix \#34_, \#33_, code style and docs (fernandezcuesta)
     + add tests (pahaz)
     + add CI integration (pahaz)
     + normal packaging (pahaz)
@@ -178,16 +180,16 @@ CHANGELOG
     + use daemon mode = False in all threads by default; detail_ (pahaz) [changed default behavior]
 
 - v.0.0.4.4
-   + fix issue #24_ - hide ssh password in logs (pahaz)
+   + fix issue \#24_ - hide ssh password in logs (pahaz)
 
 - v.0.0.4.3
-    + fix default port issue #19_ (pahaz)
+    + fix default port issue \#19_ (pahaz)
 
 - v.0.0.4.2
-    + fix Thread.daemon mode for Python < 3.3 #16_, #21_ (lewisthompson, ewrogers)
+    + fix Thread.daemon mode for Python < 3.3 \#16_, \#21_ (lewisthompson, ewrogers)
 
 - v.0.0.4.1
-    + fix CLI issues #13_ (pahaz)
+    + fix CLI issues \#13_ (pahaz)
 
 - v.0.0.4
     + daemon mode by default for all threads (fernandezcuesta, pahaz) - *incompatible*
@@ -260,16 +262,16 @@ HELP
 .. |paramiko.ProxyCommand| replace:: ``paramiko.ProxyCommand``
 .. _paramiko.ProxyCommand: http://paramiko-docs.readthedocs.org/en/latest/api/proxy.html
 
-.. _13: https://github.com/pahaz/sshtunnel/issues/13
-.. _16: https://github.com/pahaz/sshtunnel/issues/16
-.. _19: https://github.com/pahaz/sshtunnel/issues/19
-.. _21: https://github.com/pahaz/sshtunnel/issues/21
-.. _24: https://github.com/pahaz/sshtunnel/issues/24
-.. _29: https://github.com/pahaz/sshtunnel/issues/29
-.. _33: https://github.com/pahaz/sshtunnel/issues/33
-.. _34: https://github.com/pahaz/sshtunnel/issues/34
-.. _41: https://github.com/pahaz/sshtunnel/issues/41
-.. _43: https://github.com/pahaz/sshtunnel/issues/43
+.. _\#13: https://github.com/pahaz/sshtunnel/issues/13
+.. _\#16: https://github.com/pahaz/sshtunnel/issues/16
+.. _\#19: https://github.com/pahaz/sshtunnel/issues/19
+.. _\#21: https://github.com/pahaz/sshtunnel/issues/21
+.. _\#24: https://github.com/pahaz/sshtunnel/issues/24
+.. _\#29: https://github.com/pahaz/sshtunnel/issues/29
+.. _\#33: https://github.com/pahaz/sshtunnel/issues/33
+.. _\#34: https://github.com/pahaz/sshtunnel/issues/34
+.. _\#41: https://github.com/pahaz/sshtunnel/issues/41
+.. _\#43: https://github.com/pahaz/sshtunnel/issues/43
 .. _detail: https://github.com/pahaz/sshtunnel/commit/64af238b799b0e0057c4f9b386cda247e0006da9#diff-76bc1662a114401c2954deb92b740081R127
 
 .. |CircleCI| image:: https://circleci.com/gh/pahaz/sshtunnel.svg?style=svg

--- a/README.rst
+++ b/README.rst
@@ -1,23 +1,23 @@
+|CircleCI|
 
-.. image:: https://circleci.com/gh/pahaz/sshtunnel.svg?style=svg
-   :target: https://circleci.com/gh/pahaz/sshtunnel
+|DwnMonth|
+|DwnWeek|
+|DwnDay|
 
-.. image:: https://img.shields.io/pypi/dm/sshtunnel.svg
 
-.. image:: https://img.shields.io/pypi/dw/sshtunnel.svg
-
-.. image:: https://img.shields.io/pypi/dd/sshtunnel.svg
-
-**WORK WITH**: python 2.6, python 2.7, python 3.3, python 3.4, python 3.5
+**WORKS WITH**: python 2.6, python 2.7, python 3.2, python 3.3, python 3.4,
+python 3.5
 
 **Author**: `Pahaz Blinov <https://github.com/pahaz>`_
 
 **Repo**: https://github.com/pahaz/sshtunnel/
 
-Inspired by https://github.com/jmagnusson/bgtunnel but it doesn't work on Windows.
+Inspired by https://github.com/jmagnusson/bgtunnel but it doesn't work on
+Windows.
+
 See also: https://github.com/paramiko/paramiko/blob/master/demos/forward.py
 
-Require `paramiko`.
+**Requires**: `paramiko`_.
 
 Install
 =======
@@ -30,10 +30,15 @@ or ::
 
     easy_install sshtunnel
 
-SSH tunnels to remote server
-============================
+Install from source::
 
-Useful when you need to connect to local port on remote server through ssh
+    python setup.py develop
+
+
+Usage examples: SSH tunnel to remote server
+===========================================
+
+Useful when you need to connect to a local port on remote server through ssh
 tunnel. It works by opening a port forwarding ssh connection in the
 background, using threads. The connection(s) are closed when explicitly
 calling the `close` method of the returned SSHTunnelForwarder object.::
@@ -43,20 +48,20 @@ calling the `close` method of the returned SSHTunnelForwarder object.::
                                 |
     -------------+              |    +----------+               +---------
         LOCAL    |              |    |  REMOTE  |               | PRIVATE
-        SERVER   | <== SSH ========> |  SERVER  | <== local ==> | SERVER
+        CLIENT   | <== SSH ========> |  SERVER  | <== local ==> | SERVER
     -------------+              |    +----------+               +---------
                                 |
                              FIREWALL
 
     ----------------------------------------------------------------------
 
-Fig1: How to connect to PRIVATE SERVER throw SSH tunnel.
+Fig1: How to connect to PRIVATE SERVER through SSH tunnel.
 
 
-Ex 1
-----
+Example 1
+---------
 
-::
+.. code-block: py
 
     from sshtunnel import SSHTunnelForwarder
 
@@ -69,14 +74,16 @@ Ex 1
     server.start()
 
     print(server.local_bind_port)
-    # work with `SECRET SERVICE` throw `server.local_bind_port`.
+    # work with `SECRET SERVICE` through `server.local_bind_port`.
 
     server.stop()
 
-Ex 2
-----
+Example 2
+---------
 
-Example of a port forwarding for the Vagrant MySQL local port::
+Example of a port forwarding for the Vagrant MySQL local port:
+
+.. code-block: py
 
     from sshtunnel import SSHTunnelForwarder
     from time import sleep
@@ -94,97 +101,114 @@ Example of a port forwarding for the Vagrant MySQL local port::
 
     print('FINISH!')
 
-Or simple use CLI::
+Or simply using the CLI:
+
+.. code-block: bash
 
     python -m sshtunnel -U vagrant -P vagrant -L :3306 -R 127.0.0.1:3306 -p 2222 localhost
 
 API/arguments
 =============
 
-`SSHTunnelForwarder` arguments
-------------------------------
+``SSHTunnelForwarder`` arguments
+--------------------------------
 
-This is an incomplete list of arguments.  See `__init__()` method of `SSHTunnelForwarder` class in [sshtunnel.py](sshtunnel.py) for a full list.
+This is an incomplete list of arguments.  See ``__init__()`` method of
+``SSHTunnelForwarder`` class in [sshtunnel.py](sshtunnel.py) for a full list.
 
-`ssh_proxy = None`
-------------------
+``ssh_proxy = None``
+--------------------
 
-Accepts a [paramiko.ProxyCommand](http://paramiko-docs.readthedocs.org/en/latest/api/proxy.html) object which all SSH traffic will be passed through.  See either the [paramiko.ProxyCommand documentation](http://paramiko-docs.readthedocs.org/en/latest/api/proxy.html) or `ProxyCommand` in `ssh_config(5)` for more information.
+Accepts a |paramiko.ProxyCommand|_
+object where all SSH traffic will be passed through.
+See either the |paramiko.ProxyCommand|_ documentation
+or ``ProxyCommand`` in ``ssh_config(5)`` for more information.
 
-Note `ssh_proxy` overrides any `ProxyCommand` sourced from the user's `ssh_config`.
+> Note: ``ssh_proxy`` overrides any ``ProxyCommand`` sourced from the user
+``ssh_config``.
 
-Note `ssh_proxy` is ignored if `ssh_proxy_enabled != True`.
+> Note: ``ssh_proxy` is ignored if ``ssh_proxy_enabled != True``.
 
-`ssh_proxy_enabled = True`
---------------------------
+``ssh_proxy_enabled = True``
+----------------------------
 
-If true (default) and the user's `ssh_config` file contains a `ProxyCommand` directive that matches the specified `ssh_address_or_host` (or first positional argument) `SSHTunnelForwarder` will create a [paramiko.ProxyCommand](http://paramiko-docs.readthedocs.org/en/latest/api/proxy.html) object which all SSH traffic will be passed through.  See the [ssh_proxy](#ssh_proxy) argument for more details.
+If True (default) and the user's ``ssh_config`` file contains a
+``ProxyCommand`` directive that matches the specified
+``ssh_address_or_host`` (or first positional argument),
+``SSHTunnelForwarder`` will create a |paramiko.ProxyCommand|_ object where all
+SSH traffic will be passed through.
+See the ``ssh_proxy`` argument for more details.
 
 
 CONTRIBUTORS
 ============
 
- - [Cameron Maske](https://github.com/cameronmaske)
- - [Gustavo Machado](https://github.com/gdmachado)
- - [Colin Jermain](https://github.com/cjermain)
- - [J.M. Fernández](https://github.com/fernandezcuesta) - (big thanks!)
- - [Lewis Thompson](https://github.com/lewisthompson)
- - [Erik Rogers](https://github.com/ewrogers)
- - [Mart Sõmermaa](https://github.com/mrts)
+ - `Cameron Maske <https://github.com/cameronmaske>`_
+ - `Gustavo Machado <https://github.com/gdmachado>`_
+ - `Colin Jermain <https://github.com/cjermain>`_
+ - `J.M. Fernández <https://github.com/fernandezcuesta>`_ - (big thanks!)
+ - `Lewis Thompson <https://github.com/lewisthompson>`_
+ - `Erik Rogers <https://github.com/ewrogers>`_
+ - `Mart Sõmermaa <https://github.com/mrts>`_
+ - `Chronial <https://github.com/Chronial>`_
 
 CHANGELOG
 =========
 
-## work in progres ##
- - new feature
+- v.0.0.7
+  + Tunnels can now be stopped and started safely (#41_)
+  + Add timeout to SSH gateway and keep-alive messages (#29_)
+  + Allow sending a pkey directly (#43_)
+  + Add ``-V`` CLI option to show current version
+  + Refactoring
 
-## v.0.0.6 ##
- - add `-S` CLI options for ssh private key password support (pahaz)
+- v.0.0.6
+  + add ``-S`` CLI options for ssh private key password support (pahaz)
 
-## v.0.0.5 ##
- - add `ssh_proxy` argument, as well as `ssh_config(5)` `ProxyCommand` support (lewisthompson)
- - add some python 2.6 compatibility fixes (mrts)
- - `paramiko.transport` inherits handlers of loggers passed to `SSHTunnelForwarder` (fernandezcuesta)
- - fix #34, #33, code style and docs (fernandezcuesta)
- - add tests (pahaz)
- - add CI integration (pahaz)
- - normal packaging (pahaz)
- - disable check distenation socket connection by `SSHTunnelForwarder.local_is_up` (pahaz) [changed default behavior]
- - use daemon mode = False in all threads by default. `detail <https://github.com/pahaz/sshtunnel/commit/64af238b799b0e0057c4f9b386cda247e0006da9#diff-76bc1662a114401c2954deb92b740081R127>`_ (pahaz) [changed default behavior]
+- v.0.0.5
+  + add ``ssh_proxy`` argument, as well as ``ssh_config(5)`` ``ProxyCommand`` support (lewisthompson)
+  + add some python 2.6 compatibility fixes (mrts)
+  + ``paramiko.transport`` inherits handlers of loggers passed to ``SSHTunnelForwarder`` (fernandezcuesta)
+  + fix #34_, #33_, code style and docs (fernandezcuesta)
+  + add tests (pahaz)
+  + add CI integration (pahaz)
+  + normal packaging (pahaz)
+  + disable check distenation socket connection by ``SSHTunnelForwarder.local_is_up`` (pahaz) [changed default behavior]
+  + use daemon mode = False in all threads by default; detail_ (pahaz) [changed default behavior]
 
-## v.0.0.4.4 ##
- - fix issuse `#24 <https://github.com/pahaz/sshtunnel/issues/24>`_ - hide ssh password in logs (pahaz)
+- v.0.0.4.4
+  + fix issue #24_ - hide ssh password in logs (pahaz)
 
-## v.0.0.4.3 ##
- - fix default port issuse `#19 <https://github.com/pahaz/sshtunnel/issues/19>`_ (pahaz)
+- v.0.0.4.3
+  + fix default port issue #19_ (pahaz)
 
-## v.0.0.4.2 ##
- - fix Thread.daemon mode for Python < 3.3 `#16 <https://github.com/pahaz/sshtunnel/issues/16>`_, `#21 <https://github.com/pahaz/sshtunnel/issues/21>`_ (lewisthompson, ewrogers)
+- v.0.0.4.2
+  + fix Thread.daemon mode for Python < 3.3 #16_, #21_ (lewisthompson, ewrogers)
 
-## v.0.0.4.1 ##
- - fix CLI issues `#13 <https://github.com/pahaz/sshtunnel/issues/21>`_ (pahaz)
+- v.0.0.4.1
+  + fix CLI issues #13_ (pahaz)
 
-## v.0.0.4 ##
- - daemon mode by default for all threads (fernandezcuesta, pahaz) - *incompatible*
- - move `make_ssh_forward_server` to `SSHTunnelForwarder.make_ssh_forward_server` (pahaz, fernandezcuesta) - *incompatible*
- - move `make_ssh_forward_handler` to `SSHTunnelForwarder.make_ssh_forward_handler_class` (pahaz, fernandezcuesta) - *incompatible*
- - rename `open` to `open_tunnel` (fernandezcuesta) - *incompatible*
- - add CLI interface (fernandezcuesta)
- - support opening several tunnels at once (fernandezcuesta)
- - improve stability and readability (fernandezcuesta, pahaz)
- - improve logging (fernandezcuesta, pahaz)
- - add `raise_exception_if_any_forwarder_have_a_problem` argument for opening several tunnels at once (pahaz)
- - add `ssh_config_file` argument support (fernandezcuesta)
- - add Python 3 support (fernandezcuesta, pahaz)
+- v.0.0.4
+  + daemon mode by default for all threads (fernandezcuesta, pahaz) - *incompatible*
+  + move ``make_ssh_forward_server`` to ``SSHTunnelForwarder.make_ssh_forward_server`` (pahaz, fernandezcuesta) - *incompatible*
+  + move ``make_ssh_forward_handler`` to ``SSHTunnelForwarder.make_ssh_forward_handler_class`` (pahaz, fernandezcuesta) - *incompatible*
+  + rename ``open`` to ``open_tunnel`` (fernandezcuesta) - *incompatible*
+  + add CLI interface (fernandezcuesta)
+  + support opening several tunnels at once (fernandezcuesta)
+  + improve stability and readability (fernandezcuesta, pahaz)
+  + improve logging (fernandezcuesta, pahaz)
+  + add ``raise_exception_if_any_forwarder_have_a_problem`` argument for opening several tunnels at once (pahaz)
+  + add ``ssh_config_file`` argument support (fernandezcuesta)
+  + add Python 3 support (fernandezcuesta, pahaz)
 
-## v.0.0.3 ##
- - add `threaded` options (cameronmaske)
- - fix exception error message, correctly printing destination address (gdmachado)
- - fix pip install fails (cjermain, pahaz)
+- v.0.0.3
+  + add ``threaded`` options (cameronmaske)
+  + fix exception error message, correctly printing destination address (gdmachado)
+  + fix pip install fails (cjermain, pahaz)
 
-## v.0.0.1 ##
- - `SSHTunnelForwarder` class (pahaz)
- - `open` function (pahaz)
+- v.0.0.1
+  + ``SSHTunnelForwarder`` class (pahaz)
+  + ``open`` function (pahaz)
 
 HELP
 ====
@@ -230,3 +254,24 @@ HELP
       -t, --threaded        Allow concurrent connections to each tunnel
       -v, --verbosity       Increase output verbosity (default: 40)
 
+
+.. _paramiko: http://www.paramiko.org/
+.. |paramiko.ProxyCommand| replace:: ``paramiko.ProxyCommand``
+.. _paramiko.ProxyCommand: http://paramiko-docs.readthedocs.org/en/latest/api/proxy.html
+.. _#13: https://github.com/pahaz/sshtunnel/issues/13
+.. _#16: https://github.com/pahaz/sshtunnel/issues/16
+.. _#19: https://github.com/pahaz/sshtunnel/issues/19
+.. _#21: https://github.com/pahaz/sshtunnel/issues/21
+.. _#24: https://github.com/pahaz/sshtunnel/issues/24
+.. _#29: https://github.com/pahaz/sshtunnel/issues/29
+.. _#33: https://github.com/pahaz/sshtunnel/issues/33
+.. _#34: https://github.com/pahaz/sshtunnel/issues/34
+.. _#41: https://github.com/pahaz/sshtunnel/issues/41
+.. _#43: https://github.com/pahaz/sshtunnel/issues/43
+.. _detail: https://github.com/pahaz/sshtunnel/commit/64af238b799b0e0057c4f9b386cda247e0006da9#diff-76bc1662a114401c2954deb92b740081R127
+
+.. |CircleCI| image:: https://circleci.com/gh/pahaz/sshtunnel.svg?style=svg
+   :target: https://circleci.com/gh/pahaz/sshtunnel
+.. |DwnMonth| image:: https://img.shields.io/pypi/dm/sshtunnel.svg
+.. |DwnWeek| image:: https://img.shields.io/pypi/dw/sshtunnel.svg
+.. |DwnDay| image:: https://img.shields.io/pypi/dd/sshtunnel.svg

--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,20 @@
 .. image:: https://circleci.com/gh/pahaz/sshtunnel.svg?style=svg
    :target: https://circleci.com/gh/pahaz/sshtunnel
 
-**Author**: **[Pahaz Blinov](https://github.com/pahaz)**
+.. image:: https://img.shields.io/pypi/dm/sshtunnel.svg
+
+.. image:: https://img.shields.io/pypi/dw/sshtunnel.svg
+
+.. image:: https://img.shields.io/pypi/dd/sshtunnel.svg
+
+**WORKS WITH**: python 2.6, python 2.7, python 3.3, python 3.4, python 3.5
+
+**Author**: `Pahaz Blinov <https://github.com/pahaz>`_
 
 **Repo**: https://github.com/pahaz/sshtunnel/
 
-Inspired by https://github.com/jmagnusson/bgtunnel but it doesn't work on Windows.  
+Inspired by https://github.com/jmagnusson/bgtunnel but it doesn't work on
+Windows.
 See also: https://github.com/paramiko/paramiko/blob/master/demos/forward.py
 
 Require `paramiko`.
@@ -18,9 +27,15 @@ Install
 
     pip install sshtunnel
 
-or :: 
+or ::
 
     easy_install sshtunnel
+
+
+Install from source::
+
+    git clone https://github.com/pahaz/sshtunnel.git
+    python sshtunnel/setup.py develop
 
 SSH tunnels to remote server
 ============================
@@ -31,7 +46,7 @@ background, using threads. The connection(s) are closed when explicitly
 calling the `close` method of the returned SSHTunnelForwarder object.::
 
     ----------------------------------------------------------------------
-    
+
                                 |
     -------------+              |    +----------+               +---------
         LOCAL    |              |    |  REMOTE  |               | PRIVATE
@@ -39,7 +54,7 @@ calling the `close` method of the returned SSHTunnelForwarder object.::
     -------------+              |    +----------+               +---------
                                 |
                              FIREWALL
-    
+
     ----------------------------------------------------------------------
 
 Fig1: How to connect to PRIVATE SERVER throw SSH tunnel.
@@ -51,18 +66,18 @@ Ex 1
 ::
 
     from sshtunnel import SSHTunnelForwarder
-    
+
     server = SSHTunnelForwarder(
         ('pahaz.urfuclub.ru', 22),
         ssh_username="pahaz",
         ssh_password="secret",
         remote_bind_address=('127.0.0.1', 5555))
-    
+
     server.start()
-    
+
     print(server.local_bind_port)
     # work with `SECRET SERVICE` throw `server.local_bind_port`.
-    
+
     server.stop()
 
 Ex 2
@@ -72,18 +87,18 @@ Example of a port forwarding for the Vagrant MySQL local port::
 
     from sshtunnel import SSHTunnelForwarder
     from time import sleep
-    
+
     with SSHTunnelForwarder(
         ('localhost', 2222),
         ssh_username="vagrant",
         ssh_password="vagrant",
         remote_bind_address=('127.0.0.1', 3306)) as server:
-    
+
         print(server.local_bind_port)
         while True:
             # press Ctrl-C for stopping
             sleep(1)
-    
+
     print('FINISH!')
 
 Or simple use CLI::
@@ -124,15 +139,10 @@ CONTRIBUTORS
  - [Erik Rogers](https://github.com/ewrogers)
  - [Mart Sõmermaa](https://github.com/mrts)
 
-TODO
-====
-
- - Write tests!
- 
 CHANGELOG
 =========
 
-## work in progres ##
+## work in progress ##
  - new feature
 
 ## v.0.0.6 ##
@@ -146,20 +156,20 @@ CHANGELOG
  - add tests (pahaz)
  - add CI integration (pahaz)
  - normal packaging (pahaz)
+ - disable check destination socket connection by `SSHTunnelForwarder.local_is_up` (pahaz) [changed default behavior]
+ - use daemon mode = False in all threads by default. `detail <https://github.com/pahaz/sshtunnel/commit/64af238b799b0e0057c4f9b386cda247e0006da9#diff-76bc1662a114401c2954deb92b740081R127>`_ (pahaz) [changed default behavior]
 
 ## v.0.0.4.4 ##
-
- - fix issuse [#24](https://github.com/pahaz/sshtunnel/issues/24) - hide ssh password in logs (pahaz)
+ - fix issue `#24 <https://github.com/pahaz/sshtunnel/issues/24>`_ - hide ssh password in logs (pahaz)
 
 ## v.0.0.4.3 ##
-
- - fix default port issuse [#19](https://github.com/pahaz/sshtunnel/issues/19) (pahaz)
+ - fix default port issue `#19 <https://github.com/pahaz/sshtunnel/issues/19>`_ (pahaz)
 
 ## v.0.0.4.2 ##
- - fix Thread.daemon mode for Python < 3.3 [#16](https://github.com/pahaz/sshtunnel/issues/16), [#21](https://github.com/pahaz/sshtunnel/issues/21) (lewisthompson, ewrogers)
+ - fix Thread.daemon mode for Python < 3.3 `#16 <https://github.com/pahaz/sshtunnel/issues/16>`_, `#21 <https://github.com/pahaz/sshtunnel/issues/21>`_ (lewisthompson, ewrogers)
 
 ## v.0.0.4.1 ##
- - fix CLI issues/13 (pahaz)
+ - fix CLI issues `#13 <https://github.com/pahaz/sshtunnel/issues/21>`_ (pahaz)
 
 ## v.0.0.4 ##
  - daemon mode by default for all threads (fernandezcuesta, pahaz) - *incompatible*

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
 
 .. image:: https://img.shields.io/pypi/dd/sshtunnel.svg
 
-**WORK WITH**: python 2.6, python 2.7, python 3.3, python 3.4
+**WORK WITH**: python 2.6, python 2.7, python 3.3, python 3.4, python 3.5
 
 **Author**: `Pahaz Blinov <https://github.com/pahaz>`_
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,8 @@ See also: https://github.com/paramiko/paramiko/blob/master/demos/forward.py
 
 Requirements
 -------------
- * `paramiko`_
+
+* `paramiko`_
 
 Installation
 ============
@@ -124,33 +125,33 @@ object where all SSH traffic will be passed through.
 See either the |paramiko.ProxyCommand|_ documentation
 or ``ProxyCommand`` in ``ssh_config(5)`` for more information.
 
-> Note: ``ssh_proxy`` overrides any ``ProxyCommand`` sourced from the user
+ Note: ``ssh_proxy`` overrides any ``ProxyCommand`` sourced from the user
 ``ssh_config``.
 
-> Note: ``ssh_proxy`` is ignored if ``ssh_proxy_enabled != True``.
+ Note: ``ssh_proxy`` is ignored if ``ssh_proxy_enabled != True``.
 
 ``ssh_proxy_enabled = True``
 ----------------------------
 
-If True (default) and the user's ``ssh_config`` file contains a
-``ProxyCommand`` directive that matches the specified
-``ssh_address_or_host`` (or first positional argument),
-``SSHTunnelForwarder`` will create a |paramiko.ProxyCommand|_ object where all
-SSH traffic will be passed through.
+If True (default) and user's ``ssh_config`` file contains a ``ProxyCommand``
+directive that matches the specified ``ssh_address_or_host`` (or first
+positional argument), ``SSHTunnelForwarder`` will create a
+|paramiko.ProxyCommand|_ object where all SSH traffic will be passed through.
+
 See the ``ssh_proxy`` argument for more details.
 
 
 CONTRIBUTORS
 ============
 
- - `Cameron Maske <https://github.com/cameronmaske>`_
- - `Gustavo Machado <https://github.com/gdmachado>`_
- - `Colin Jermain <https://github.com/cjermain>`_
- - `J.M. Fernández <https://github.com/fernandezcuesta>`_ - (big thanks!)
- - `Lewis Thompson <https://github.com/lewisthompson>`_
- - `Erik Rogers <https://github.com/ewrogers>`_
- - `Mart Sõmermaa <https://github.com/mrts>`_
- - `Chronial <https://github.com/Chronial>`_
+- `Cameron Maske <https://github.com/cameronmaske>`_
+- `Gustavo Machado <https://github.com/gdmachado>`_
+- `Colin Jermain <https://github.com/cjermain>`_
+- `J.M. Fernández <https://github.com/fernandezcuesta>`_ - (big thanks!)
+- `Lewis Thompson <https://github.com/lewisthompson>`_
+- `Erik Rogers <https://github.com/ewrogers>`_
+- `Mart Sõmermaa <https://github.com/mrts>`_
+- `Chronial <https://github.com/Chronial>`_
 
 CHANGELOG
 =========
@@ -258,20 +259,22 @@ HELP
 .. _paramiko: http://www.paramiko.org/
 .. |paramiko.ProxyCommand| replace:: ``paramiko.ProxyCommand``
 .. _paramiko.ProxyCommand: http://paramiko-docs.readthedocs.org/en/latest/api/proxy.html
-.. _#13: https://github.com/pahaz/sshtunnel/issues/13
-.. _#16: https://github.com/pahaz/sshtunnel/issues/16
-.. _#19: https://github.com/pahaz/sshtunnel/issues/19
-.. _#21: https://github.com/pahaz/sshtunnel/issues/21
-.. _#24: https://github.com/pahaz/sshtunnel/issues/24
-.. _#29: https://github.com/pahaz/sshtunnel/issues/29
-.. _#33: https://github.com/pahaz/sshtunnel/issues/33
-.. _#34: https://github.com/pahaz/sshtunnel/issues/34
-.. _#41: https://github.com/pahaz/sshtunnel/issues/41
-.. _#43: https://github.com/pahaz/sshtunnel/issues/43
+
+.. _13: https://github.com/pahaz/sshtunnel/issues/13
+.. _16: https://github.com/pahaz/sshtunnel/issues/16
+.. _19: https://github.com/pahaz/sshtunnel/issues/19
+.. _21: https://github.com/pahaz/sshtunnel/issues/21
+.. _24: https://github.com/pahaz/sshtunnel/issues/24
+.. _29: https://github.com/pahaz/sshtunnel/issues/29
+.. _33: https://github.com/pahaz/sshtunnel/issues/33
+.. _34: https://github.com/pahaz/sshtunnel/issues/34
+.. _41: https://github.com/pahaz/sshtunnel/issues/41
+.. _43: https://github.com/pahaz/sshtunnel/issues/43
 .. _detail: https://github.com/pahaz/sshtunnel/commit/64af238b799b0e0057c4f9b386cda247e0006da9#diff-76bc1662a114401c2954deb92b740081R127
 
 .. |CircleCI| image:: https://circleci.com/gh/pahaz/sshtunnel.svg?style=svg
    :target: https://circleci.com/gh/pahaz/sshtunnel
+
 .. |DwnMonth| image:: https://img.shields.io/pypi/dm/sshtunnel.svg
 .. |DwnWeek| image:: https://img.shields.io/pypi/dw/sshtunnel.svg
 .. |DwnDay| image:: https://img.shields.io/pypi/dd/sshtunnel.svg

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|CircleCI|
+|CircleCI| |coveralls|
 
 |DwnMonth| |DwnWeek| |DwnDay|
 
@@ -35,6 +35,13 @@ Install from source::
 
     python setup.py develop
 
+Testing the package
+-------------------
+
+.. code-block:: bash
+
+    pip install -r requirements-test.txt
+    python setup.py test
 
 Usage examples: SSH tunnel to remote server
 ===========================================
@@ -276,7 +283,10 @@ HELP
 
 .. |CircleCI| image:: https://circleci.com/gh/pahaz/sshtunnel.svg?style=svg
    :target: https://circleci.com/gh/pahaz/sshtunnel
+.. |coveralls| image:: https://coveralls.io/repos/github/fernandezcuesta/sshtunnel/badge.svg?branch=devel
+   :target: https://coveralls.io/github/fernandezcuesta/sshtunnel?branch=devel
 
 .. |DwnMonth| image:: https://img.shields.io/pypi/dm/sshtunnel.svg
 .. |DwnWeek| image:: https://img.shields.io/pypi/dw/sshtunnel.svg
 .. |DwnDay| image:: https://img.shields.io/pypi/dd/sshtunnel.svg
+

--- a/README.rst
+++ b/README.rst
@@ -177,7 +177,7 @@ CHANGELOG
     + add CI integration (pahaz)
     + normal packaging (pahaz)
     + disable check distenation socket connection by ``SSHTunnelForwarder.local_is_up`` (pahaz) [changed default behavior]
-    + use daemon mode = False in all threads by default; detail_ (pahaz) [changed default behavior]
+    + use daemon mode = False in all threads by default; :ref:`detail` (pahaz) [changed default behavior]
 
 - v.0.0.4.4
    + fix issue \#24_ - hide ssh password in logs (pahaz)
@@ -262,16 +262,7 @@ HELP
 .. |paramiko.ProxyCommand| replace:: ``paramiko.ProxyCommand``
 .. _paramiko.ProxyCommand: http://paramiko-docs.readthedocs.org/en/latest/api/proxy.html
 
-.. _#13: https://github.com/pahaz/sshtunnel/issues/13
-.. _#16: https://github.com/pahaz/sshtunnel/issues/16
-.. _#19: https://github.com/pahaz/sshtunnel/issues/19
-.. _#21: https://github.com/pahaz/sshtunnel/issues/21
-.. _#24: https://github.com/pahaz/sshtunnel/issues/24
-.. _#29: https://github.com/pahaz/sshtunnel/issues/29
-.. _#33: https://github.com/pahaz/sshtunnel/issues/33
-.. _#34: https://github.com/pahaz/sshtunnel/issues/34
-.. _#41: https://github.com/pahaz/sshtunnel/issues/41
-.. _#43: https://github.com/pahaz/sshtunnel/issues/43
+
 .. _detail: https://github.com/pahaz/sshtunnel/commit/64af238b799b0e0057c4f9b386cda247e0006da9#diff-76bc1662a114401c2954deb92b740081R127
 
 .. |CircleCI| image:: https://circleci.com/gh/pahaz/sshtunnel.svg?style=svg

--- a/README.rst
+++ b/README.rst
@@ -159,9 +159,9 @@ CHANGELOG
 =========
 
 - v.0.0.7
-    + Tunnels can now be stopped and started safely (:ref:`#41`)
-    + Add timeout to SSH gateway and keep-alive messages (:ref:`#29`)
-    + Allow sending a pkey directly (:ref:`#43`)
+    + Tunnels can now be stopped and started safely (`#41`_)
+    + Add timeout to SSH gateway and keep-alive messages (`#29`_)
+    + Allow sending a pkey directly (`#43`_)
     + Add ``-V`` CLI option to show current version
     + Refactoring
 
@@ -172,24 +172,24 @@ CHANGELOG
     + add ``ssh_proxy`` argument, as well as ``ssh_config(5)`` ``ProxyCommand`` support (lewisthompson)
     + add some python 2.6 compatibility fixes (mrts)
     + ``paramiko.transport`` inherits handlers of loggers passed to ``SSHTunnelForwarder`` (fernandezcuesta)
-    + fix \#34_, \#33_, code style and docs (fernandezcuesta)
+    + fix `#34`_, `#33`_, code style and docs (fernandezcuesta)
     + add tests (pahaz)
     + add CI integration (pahaz)
     + normal packaging (pahaz)
     + disable check distenation socket connection by ``SSHTunnelForwarder.local_is_up`` (pahaz) [changed default behavior]
-    + use daemon mode = False in all threads by default; :ref:`detail` (pahaz) [changed default behavior]
+    + use daemon mode = False in all threads by default; detail_ (pahaz) [changed default behavior]
 
 - v.0.0.4.4
-   + fix issue \#24_ - hide ssh password in logs (pahaz)
+   + fix issue `#24`_ - hide ssh password in logs (pahaz)
 
 - v.0.0.4.3
-    + fix default port issue \#19_ (pahaz)
+    + fix default port issue `#19`_ (pahaz)
 
 - v.0.0.4.2
-    + fix Thread.daemon mode for Python < 3.3 \#16_, \#21_ (lewisthompson, ewrogers)
+    + fix Thread.daemon mode for Python < 3.3 `#16`_, `#21`_ (lewisthompson, ewrogers)
 
 - v.0.0.4.1
-    + fix CLI issues \#13_ (pahaz)
+    + fix CLI issues `#13`_ (pahaz)
 
 - v.0.0.4
     + daemon mode by default for all threads (fernandezcuesta, pahaz) - *incompatible*
@@ -262,7 +262,16 @@ HELP
 .. |paramiko.ProxyCommand| replace:: ``paramiko.ProxyCommand``
 .. _paramiko.ProxyCommand: http://paramiko-docs.readthedocs.org/en/latest/api/proxy.html
 
-
+.. _#13: https://github.com/pahaz/sshtunnel/issues/13
+.. _#16: https://github.com/pahaz/sshtunnel/issues/16
+.. _#19: https://github.com/pahaz/sshtunnel/issues/19
+.. _#21: https://github.com/pahaz/sshtunnel/issues/21
+.. _#24: https://github.com/pahaz/sshtunnel/issues/24
+.. _#29: https://github.com/pahaz/sshtunnel/issues/29
+.. _#33: https://github.com/pahaz/sshtunnel/issues/33
+.. _#34: https://github.com/pahaz/sshtunnel/issues/34
+.. _#41: https://github.com/pahaz/sshtunnel/issues/41
+.. _#43: https://github.com/pahaz/sshtunnel/issues/43
 .. _detail: https://github.com/pahaz/sshtunnel/commit/64af238b799b0e0057c4f9b386cda247e0006da9#diff-76bc1662a114401c2954deb92b740081R127
 
 .. |CircleCI| image:: https://circleci.com/gh/pahaz/sshtunnel.svg?style=svg

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,6 @@
 |CircleCI|
 
-|DwnMonth|
-|DwnWeek|
-|DwnDay|
+|DwnMonth| |DwnWeek| |DwnDay|
 
 
 **WORKS WITH**: python 2.6, python 2.7, python 3.2, python 3.3, python 3.4,
@@ -17,10 +15,12 @@ Windows.
 
 See also: https://github.com/paramiko/paramiko/blob/master/demos/forward.py
 
-**Requires**: `paramiko`_.
+Requirements
+-------------
+ * `paramiko`_
 
-Install
-=======
+Installation
+============
 
 ::
 
@@ -61,7 +61,7 @@ Fig1: How to connect to PRIVATE SERVER through SSH tunnel.
 Example 1
 ---------
 
-.. code-block: py
+.. code-block:: py
 
     from sshtunnel import SSHTunnelForwarder
 
@@ -83,7 +83,7 @@ Example 2
 
 Example of a port forwarding for the Vagrant MySQL local port:
 
-.. code-block: py
+.. code-block:: py
 
     from sshtunnel import SSHTunnelForwarder
     from time import sleep
@@ -103,7 +103,7 @@ Example of a port forwarding for the Vagrant MySQL local port:
 
 Or simply using the CLI:
 
-.. code-block: bash
+.. code-block:: bash
 
     python -m sshtunnel -U vagrant -P vagrant -L :3306 -R 127.0.0.1:3306 -p 2222 localhost
 
@@ -114,7 +114,7 @@ API/arguments
 --------------------------------
 
 This is an incomplete list of arguments.  See ``__init__()`` method of
-``SSHTunnelForwarder`` class in [sshtunnel.py](sshtunnel.py) for a full list.
+``SSHTunnelForwarder`` class in ``sshtunnel.py`` for a full list.
 
 ``ssh_proxy = None``
 --------------------
@@ -127,7 +127,7 @@ or ``ProxyCommand`` in ``ssh_config(5)`` for more information.
 > Note: ``ssh_proxy`` overrides any ``ProxyCommand`` sourced from the user
 ``ssh_config``.
 
-> Note: ``ssh_proxy` is ignored if ``ssh_proxy_enabled != True``.
+> Note: ``ssh_proxy`` is ignored if ``ssh_proxy_enabled != True``.
 
 ``ssh_proxy_enabled = True``
 ----------------------------
@@ -156,59 +156,59 @@ CHANGELOG
 =========
 
 - v.0.0.7
-  + Tunnels can now be stopped and started safely (#41_)
-  + Add timeout to SSH gateway and keep-alive messages (#29_)
-  + Allow sending a pkey directly (#43_)
-  + Add ``-V`` CLI option to show current version
-  + Refactoring
+    + Tunnels can now be stopped and started safely (#41_)
+    + Add timeout to SSH gateway and keep-alive messages (#29_)
+    + Allow sending a pkey directly (#43_)
+    + Add ``-V`` CLI option to show current version
+    + Refactoring
 
 - v.0.0.6
-  + add ``-S`` CLI options for ssh private key password support (pahaz)
+    + add ``-S`` CLI options for ssh private key password support (pahaz)
 
 - v.0.0.5
-  + add ``ssh_proxy`` argument, as well as ``ssh_config(5)`` ``ProxyCommand`` support (lewisthompson)
-  + add some python 2.6 compatibility fixes (mrts)
-  + ``paramiko.transport`` inherits handlers of loggers passed to ``SSHTunnelForwarder`` (fernandezcuesta)
-  + fix #34_, #33_, code style and docs (fernandezcuesta)
-  + add tests (pahaz)
-  + add CI integration (pahaz)
-  + normal packaging (pahaz)
-  + disable check distenation socket connection by ``SSHTunnelForwarder.local_is_up`` (pahaz) [changed default behavior]
-  + use daemon mode = False in all threads by default; detail_ (pahaz) [changed default behavior]
+    + add ``ssh_proxy`` argument, as well as ``ssh_config(5)`` ``ProxyCommand`` support (lewisthompson)
+    + add some python 2.6 compatibility fixes (mrts)
+    + ``paramiko.transport`` inherits handlers of loggers passed to ``SSHTunnelForwarder`` (fernandezcuesta)
+    + fix #34_, #33_, code style and docs (fernandezcuesta)
+    + add tests (pahaz)
+    + add CI integration (pahaz)
+    + normal packaging (pahaz)
+    + disable check distenation socket connection by ``SSHTunnelForwarder.local_is_up`` (pahaz) [changed default behavior]
+    + use daemon mode = False in all threads by default; detail_ (pahaz) [changed default behavior]
 
 - v.0.0.4.4
-  + fix issue #24_ - hide ssh password in logs (pahaz)
+   + fix issue #24_ - hide ssh password in logs (pahaz)
 
 - v.0.0.4.3
-  + fix default port issue #19_ (pahaz)
+    + fix default port issue #19_ (pahaz)
 
 - v.0.0.4.2
-  + fix Thread.daemon mode for Python < 3.3 #16_, #21_ (lewisthompson, ewrogers)
+    + fix Thread.daemon mode for Python < 3.3 #16_, #21_ (lewisthompson, ewrogers)
 
 - v.0.0.4.1
-  + fix CLI issues #13_ (pahaz)
+    + fix CLI issues #13_ (pahaz)
 
 - v.0.0.4
-  + daemon mode by default for all threads (fernandezcuesta, pahaz) - *incompatible*
-  + move ``make_ssh_forward_server`` to ``SSHTunnelForwarder.make_ssh_forward_server`` (pahaz, fernandezcuesta) - *incompatible*
-  + move ``make_ssh_forward_handler`` to ``SSHTunnelForwarder.make_ssh_forward_handler_class`` (pahaz, fernandezcuesta) - *incompatible*
-  + rename ``open`` to ``open_tunnel`` (fernandezcuesta) - *incompatible*
-  + add CLI interface (fernandezcuesta)
-  + support opening several tunnels at once (fernandezcuesta)
-  + improve stability and readability (fernandezcuesta, pahaz)
-  + improve logging (fernandezcuesta, pahaz)
-  + add ``raise_exception_if_any_forwarder_have_a_problem`` argument for opening several tunnels at once (pahaz)
-  + add ``ssh_config_file`` argument support (fernandezcuesta)
-  + add Python 3 support (fernandezcuesta, pahaz)
+    + daemon mode by default for all threads (fernandezcuesta, pahaz) - *incompatible*
+    + move ``make_ssh_forward_server`` to ``SSHTunnelForwarder.make_ssh_forward_server`` (pahaz, fernandezcuesta) - *incompatible*
+    + move ``make_ssh_forward_handler`` to ``SSHTunnelForwarder.make_ssh_forward_handler_class`` (pahaz, fernandezcuesta) - *incompatible*
+    + rename ``open`` to ``open_tunnel`` (fernandezcuesta) - *incompatible*
+    + add CLI interface (fernandezcuesta)
+    + support opening several tunnels at once (fernandezcuesta)
+    + improve stability and readability (fernandezcuesta, pahaz)
+    + improve logging (fernandezcuesta, pahaz)
+    + add ``raise_exception_if_any_forwarder_have_a_problem`` argument for opening several tunnels at once (pahaz)
+    + add ``ssh_config_file`` argument support (fernandezcuesta)
+    + add Python 3 support (fernandezcuesta, pahaz)
 
 - v.0.0.3
-  + add ``threaded`` options (cameronmaske)
-  + fix exception error message, correctly printing destination address (gdmachado)
-  + fix pip install fails (cjermain, pahaz)
+    + add ``threaded`` options (cameronmaske)
+    + fix exception error message, correctly printing destination address (gdmachado)
+    + fix pip install fails (cjermain, pahaz)
 
 - v.0.0.1
-  + ``SSHTunnelForwarder`` class (pahaz)
-  + ``open`` function (pahaz)
+    + ``SSHTunnelForwarder`` class (pahaz)
+    + ``open`` function (pahaz)
 
 HELP
 ====

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
     TOX_PY32: '3.2.5'
     TOX_PY33: '3.3.3'
     TOX_PY34: '3.4.3'
+    TOX_PY35: '3.5.0'
 
 dependencies:
   override:
@@ -13,7 +14,7 @@ dependencies:
     - pip install -U ipdb
     - pip install --upgrade tox
     - pip install --upgrade tox-pyenv
-    - pyenv local $TOX_PY34 $TOX_PY33 $TOX_PY32 $TOX_PY27 $TOX_PY26
+    - pyenv local $TOX_PY35 $TOX_PY34 $TOX_PY33 $TOX_PY32 $TOX_PY27 $TOX_PY26
 
 test:
   override:

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'paramiko>=1.15.2',
+        'six>=1.10',
     ],
 
     # List additional groups of dependencies here (e.g. development

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,6 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'paramiko>=1.15.2',
-        'six>=1.10',
     ],
 
     # List additional groups of dependencies here (e.g. development

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -342,7 +342,7 @@ class _ThreadingForwardServer(socketserver.ThreadingMixIn, _ForwardServer):
     """
     Allows concurrent connections to each tunnel
     """
-    # Will cleanly stop threads created by ThreadingMixIn when quitting
+    # If True, cleanly stop threads created by ThreadingMixIn when quitting
     daemon_threads = DAEMON
 
 

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -167,7 +167,7 @@ def check_addresses(address_list):
         check_address(address)
 
 
-def create_logger(logger=None, loglevel=DEFAULT_LOGLEVEL):
+def create_logger(logger=None, loglevel=None):
     """
     Attaches or creates a new logger and creates console handlers if not
     present
@@ -176,12 +176,14 @@ def create_logger(logger=None, loglevel=DEFAULT_LOGLEVEL):
         '{0}.SSHTunnelForwarder'.format(__name__)
     )
     if not logger.handlers:  # if no handlers, add a new one (console)
-        logger.setLevel(loglevel)
+        logger.setLevel(loglevel or DEFAULT_LOGLEVEL)
         console_handler = logging.StreamHandler()
         console_handler.setFormatter(
             logging.Formatter('%(asctime)s | %(levelname)-8s| %(message)s')
         )
         logger.addHandler(console_handler)
+    elif loglevel:  # only override if loglevel was set
+        logger.setLevel(loglevel)
 
     check_paramiko_handlers()
     return logger
@@ -421,7 +423,7 @@ class SSHTunnelForwarder(object):
         if not issubclass(_Handler, socketserver.BaseRequestHandler):
             msg = "base_ssh_forward_handler is not a subclass " \
                   "socketserver.BaseRequestHandler"
-            raise BaseSSHTunnelForwarderError(msg)
+            self._raise(BaseSSHTunnelForwarderError, msg)
 
         class Handler(_Handler):
             """ handler class for remote tunnels """
@@ -441,7 +443,18 @@ class SSHTunnelForwarder(object):
         _Handler = self.make_ssh_forward_handler_class(remote_address)
         _Server = self.make_ssh_forward_server_class(remote_address)
         try:
-            return _Server(local_bind_address, _Handler)
+            ssh_forward_server = _Server(local_bind_address, _Handler)
+            if ssh_forward_server:
+                self._server_list.append(ssh_forward_server)
+            else:
+                self._raise(
+                    BaseSSHTunnelForwarderError,
+                    'Problem with make ssh {0} <> {1} forwarder. You can '
+                    'suppress this exception by using the '
+                    '`raise_exception_if_any_forwarder_have_a_problem` '
+                    'argument'.format(address_to_str(local_bind_address),
+                                      address_to_str(remote_address))
+                )
         except IOError:
             self.logger.error("Couldn't open tunnel {0} <> {1} "
                               "might be in use or destination not reachable."
@@ -451,45 +464,46 @@ class SSHTunnelForwarder(object):
     def __init__(
             self,
             ssh_address_or_host=None,
+            ssh_config_file="~/.ssh/config",
             ssh_host_key=None,
-            ssh_username=None,
             ssh_password=None,
             ssh_private_key=None,
             ssh_private_key_password=None,
             ssh_proxy=None,
             ssh_proxy_enabled=True,
-            remote_bind_address=None,
+            ssh_username=None,
             local_bind_address=None,
-            remote_bind_addresses=None,
             local_bind_addresses=None,
-            set_keepalive=0,
-            ssh_config_file="~/.ssh/config",
             logger=None,
-            threaded=True,  # old version False
             raise_exception_if_any_forwarder_have_a_problem=True,
+            remote_bind_address=None,
+            remote_bind_addresses=None,
+            set_keepalive=0,
+            threaded=True,  # old version False
             use_ssh_config=True,
             **kwargs  # for backwards compatibility
     ):
         """
         ssh_arguments:
           (ssh_address or ssh_host)
+          ssh_config_file=~/.ssh/config
           ssh_host_key=None
-          ssh_username=None
           ssh_password=None
           ssh_private_key=None
-          remote_bind_address=None
-          local_bind_address=None
-          remote_bind_addresses=None,
-          local_bind_addresses=None,
-          threaded=True
-          ssh_port=22
-          ssh_host=None
-          set_keepalive=0,
-          ssh_config_file=~/.ssh/config
+          ssh_private_key_password=None,
           ssh_proxy=None
           ssh_proxy_enabled=True
-          use_ssh_config=True
+          ssh_username=None
+          local_bind_address=None
+          local_bind_addresses=None,
           logger=__name__
+          remote_bind_address=None
+          remote_bind_addresses=None,
+          set_keepalive=0,
+          threaded=True
+          use_ssh_config=True
+          ssh_port=22  # DEPRECATED
+          ssh_host=None  # DEPRECATED
 
         ssh_address is (host, port) or host
         use *remote_bind_addresses* if you want open more than one tunnel else
@@ -507,171 +521,148 @@ class SSHTunnelForwarder(object):
         Or use `forwarder.local_bind_port` for getting local forwarding port if
         you use only one tunnel.
         """
-        if logger:
-            self.logger = logger
-            # Ensure paramiko.transport has a console handler
-            check_paramiko_handlers(logger=logger)
-        else:
-            self.logger = create_logger()
+        self.logger = logger or create_logger()
+        # Ensure paramiko.transport has a console handler
+        check_paramiko_handlers(logger=logger)
+
+        self.ssh_address_or_host = ssh_address_or_host
+        self.use_ssh_config = use_ssh_config
+        self.ssh_config_file = ssh_config_file
+        self.ssh_username = ssh_username
+        self.ssh_password = ssh_password
+        self.ssh_host_key = ssh_host_key
+        self.ssh_private_key_password = ssh_private_key_password
+        self.ssh_private_key = ssh_private_key
+        self.ssh_proxy = ssh_proxy
+        self.ssh_proxy_enabled = ssh_proxy_enabled
+        self.set_keepalive = set_keepalive
+        self._raise_fwd_exc = raise_exception_if_any_forwarder_have_a_problem
+        self._threaded = threaded
+        self._is_started = False
 
         # ssh host port
-        if 'ssh_address' in kwargs:
-            warnings.warn("'ssh_address' is DEPRECATED use "
-                          "'ssh_address_or_host' or 1st positional argument",
-                          DeprecationWarning)
-            if ssh_address_or_host:
-                raise ValueError("You can't use 'ssh_address' and "
-                                 "'ssh_address_or_host'. Please use one "
-                                 "'ssh_address_or_host'")
-            else:
-                ssh_address_or_host = kwargs.pop('ssh_address')
+        self._get_ssh_address_or_host('ssh_address', kwargs)
+        self._get_ssh_address_or_host('ssh_host', kwargs)
 
-        if 'ssh_host' in kwargs:
-            warnings.warn("'ssh_host' is DEPRECATED use "
-                          "'ssh_address_or_host' or 1st positional argument",
-                          DeprecationWarning)
-            if ssh_address_or_host:
-                raise ValueError("You can't use 'ssh_host' and "
-                                 "'ssh_address_or_host'. Please use one "
-                                 "'ssh_address_or_host'")
-            else:
-                ssh_address_or_host = kwargs.pop('ssh_host')
-
-        if isinstance(ssh_address_or_host, tuple):
-            (ssh_host, ssh_port) = ssh_address_or_host
+        if isinstance(self.ssh_address_or_host, tuple):
+            (self.ssh_host, self.ssh_port) = self.ssh_address_or_host
         else:
-            ssh_host = ssh_address_or_host
-            ssh_port = kwargs.pop('ssh_port', None)
-
-        # remote binds
-        if not remote_bind_address and not remote_bind_addresses:
-            raise ValueError("No remote bind addresses use "
-                             "'remote_bind_address' or 'remote_bind_addresses'"
-                             " argument")
-        elif remote_bind_address and remote_bind_addresses:
-            raise ValueError("You can't use both 'remote_bind_address' and "
-                             "'remote_bind_addresses' argument. Use one of "
-                             "them.")
-        if remote_bind_address:
-            remote_bind_addresses = [remote_bind_address]
-
-        # local binds
-        if not local_bind_address and not local_bind_addresses:
-            local_bind_addresses = []
-        elif local_bind_address and local_bind_addresses:
-            raise ValueError("You can't use both 'local_bind_address' and "
-                             "'local_bind_addresses' arguments. Use one of "
-                             "them.")
-        if local_bind_address:
-            local_bind_addresses = [local_bind_address]
-
-        if len(local_bind_addresses) > len(remote_bind_addresses):
-            raise ValueError('Too many local bind addresses '
-                             '(local_bind_addresses > remote_bind_addresses)')
-        elif len(local_bind_addresses) < len(remote_bind_addresses):
-            count = len(remote_bind_addresses) - len(local_bind_addresses)
-            for x in range(count):
-                local_bind_addresses.append(('0.0.0.0', 0))
+            self.ssh_host = self.ssh_address_or_host
+            self.ssh_port = kwargs.pop('ssh_port', None)
 
         if kwargs:
             raise ValueError('Unknown arguments: {0}'.format(kwargs))
 
-        del ssh_address_or_host  # is this useful?
+        # remote binds
+        self._get_binds(remote_bind_address, remote_bind_addresses)
+        # local binds
+        self._get_binds(local_bind_address, local_bind_addresses, remote=False)
+
+        del self.ssh_address_or_host  # is this useful?
 
         if use_ssh_config:
-            # Try to read ~/.ssh/config
-            ssh_config = paramiko.SSHConfig()
-            try:
-                # open the ssh config file
-                with open(expanduser(ssh_config_file), 'r') as f:
-                    ssh_config.parse(f)
-                # looks for information for the destination system
-                hostname_info = ssh_config.lookup(ssh_host)
-                # gather settings for user, port and identity file
-                # last resort: use the 'login name' of the user
-                ssh_username = (
-                    ssh_username or
-                    hostname_info.get('user', getpass.getuser())
-                )
-                ssh_private_key = (
-                    ssh_private_key or
-                    hostname_info.get('identityfile', [None])[0]
-                )
-                ssh_port = ssh_port or hostname_info.get('port')
-                proxycommand = hostname_info.get('proxycommand')
-                ssh_proxy = (
-                    ssh_proxy or paramiko.ProxyCommand(proxycommand)
-                    if proxycommand else None
-                )
-            except IOError:
-                self.logger.warning(
-                    'Could not read SSH configuration file: {0}'
-                    .format(ssh_config_file)
-                )
+            self.read_ssh_config()
 
-        if not ssh_password:
-            ssh_private_key = paramiko.RSAKey.from_private_key_file(
-                ssh_private_key,
-                password=ssh_private_key_password
-            ) if ssh_private_key else None
-
-            # Check if a private key was supplied or found in ssh_config
-            if not ssh_private_key:
-                raise ValueError('No password or private key available!')
-
-        if not ssh_port:
-            ssh_port = 22
-
-        check_host(ssh_host)
-        check_port(ssh_port)
-        check_addresses(remote_bind_addresses)
-        check_addresses(local_bind_addresses)
-
-        self._server_list = []
-
-        self._ssh_username = ssh_username
-        self._ssh_password = ssh_password
-        self._ssh_host_key = ssh_host_key
-        self._ssh_private_key = ssh_private_key
-
-        self._threaded = threaded
+        self._consolidate_settings()
+        check_host(self.ssh_host)
+        check_port(self.ssh_port)
+        check_addresses(self._remote_binds)
+        check_addresses(self._local_binds)
 
         self._local_interfaces = self._get_local_interfaces()
-
         self.logger.info('Connecting to gateway: {0}:{1} as user "{2}".'
-                         .format(ssh_host, ssh_port, ssh_username))
+                         .format(self.ssh_host,
+                                 self.ssh_port,
+                                 self.ssh_username))
 
+        self.logger.debug('Concurrent connections allowed: {0}'
+                          .format(self._threaded))
+
+    def read_ssh_config(self):
+        """Read ssh_config and populate SSHTunnelForwarder attributes"""
+        # Try to read ~/.ssh/config
+        ssh_config = paramiko.SSHConfig()
+        try:
+            # open the ssh config file
+            with open(expanduser(self.ssh_config_file), 'r') as f:
+                ssh_config.parse(f)
+            # looks for information for the destination system
+            hostname_info = ssh_config.lookup(self.ssh_host)
+            # gather settings for user, port and identity file
+            # last resort: use the 'login name' of the user
+            self.ssh_username = (
+                self.ssh_username or
+                hostname_info.get('user', getpass.getuser())
+            )
+            self.ssh_private_key = (
+                self.ssh_private_key or
+                hostname_info.get('identityfile', [None])[0]
+            )
+            self.ssh_port = self.ssh_port or hostname_info.get('port')
+            proxycommand = hostname_info.get('proxycommand')
+            self.ssh_proxy = (
+                self.ssh_proxy or paramiko.ProxyCommand(proxycommand)
+                if proxycommand else None
+            )
+        except IOError:
+            self.logger.warning(
+                'Could not read SSH configuration file: {0}'
+                .format(self.ssh_config_file)
+            )
+
+    def _consolidate_settings(self):
+        """Get sure everything is in place"""
+        count = len(self._remote_binds) - len(self._local_binds)
+
+        if count < 0:
+            raise ValueError('Too many local bind addresses '
+                             '(local_bind_addresses > remote_bind_addresses)')
+        self._local_binds.extend([('0.0.0.0', 0) for x in range(count)])
+        if not self.ssh_password:
+            self.ssh_private_key = paramiko.RSAKey.from_private_key_file(
+                self.ssh_private_key,
+                password=self.ssh_private_key_password
+            ) if self.ssh_private_key else None
+
+            # Check if a private key was supplied or found in ssh_config
+            if not self.ssh_private_key:
+                raise ValueError('No password or private key available!')
+
+        if not self.ssh_port:
+            self.ssh_port = 22
+
+    def _raise(self, exception, reason):
+        if self._raise_fwd_exc:
+            raise exception(reason)
+
+    def _get_transport(self):
+        """Create self._transport"""
+        if self.ssh_proxy and self.ssh_proxy_enabled:
+            self.logger.debug('Connecting with ProxyCommand {0}'
+                              .format(repr(self.ssh_proxy.cmd)))
+            self._transport = paramiko.Transport(self.ssh_proxy)
+        else:
+            self._transport = paramiko.Transport((self.ssh_host,
+                                                  self.ssh_port))
+        self._transport.set_keepalive(self.set_keepalive)
+        self._transport.daemon = self.daemon_transport
+
+    def create_tunnels(self):
+        """
+        """
         # CREATE THE TUNNELS
         self.tunnel_is_up = {}  # handle status of the other side of the tunnel
         try:
-            if ssh_proxy and ssh_proxy_enabled:
-                self.logger.debug('Connecting with ProxyCommand {0}'
-                                  .format(repr(ssh_proxy.cmd)))
-                self._transport = paramiko.Transport(ssh_proxy)
-            else:
-                self._transport = paramiko.Transport((ssh_host, ssh_port))
-            self._transport.set_keepalive(set_keepalive)
-            self._transport.daemon = self.daemon_transport
-            for (rem, loc) in zip(remote_bind_addresses, local_bind_addresses):
-                ssh_forward_server = self.make_ssh_forward_server(rem, loc)
-                if ssh_forward_server:
-                    self._server_list.append(ssh_forward_server)
-                elif raise_exception_if_any_forwarder_have_a_problem:
-                    raise BaseSSHTunnelForwarderError(
-                        'Problem with make ssh {0} <> {1} forwarder. You can '
-                        'suppress this exception by using the '
-                        '`raise_exception_if_any_forwarder_have_a_problem` '
-                        'argument'.format(address_to_str(loc),
-                                          address_to_str(rem))
-                    )
-
+            self._get_transport()
+            for (rem, loc) in zip(self._remote_binds, self._local_binds):
+                self.make_ssh_forward_server(rem, loc)
         except paramiko.SSHException:
-            msg = 'Could not connect to gateway: {0}'.format(ssh_host)
+            msg = 'Could not connect to gateway: {0}'.format(self.ssh_host)
             self.logger.error(msg)
             raise BaseSSHTunnelForwarderError(msg)
         except socket.gaierror:  # raised by paramiko.Transport
             msg = 'Could not resolve IP address for {0}, aborting!' \
-                .format(ssh_host)
+                .format(self.ssh_host)
             self.logger.error(msg)
             raise BaseSSHTunnelForwarderError(msg)
         except BaseSSHTunnelForwarderError as e:
@@ -679,28 +670,51 @@ class SSHTunnelForwarder(object):
             self.logger.error(msg)
             raise BaseSSHTunnelForwarderError(msg)
 
-        self.logger.debug('Concurrent connections allowed: {0}'
-                          .format(self._threaded))
-        self._is_started = False
+    def _get_binds(self, bind_address, bind_addresses, remote=True):
+        """
+        """
+        addr_kind = 'remote' if remote else 'local'
+
+        if not bind_address and not bind_addresses:
+            if remote:
+                raise ValueError("No {0} bind addresses specified. Use "
+                                 "'{0}_bind_address' or '{0}_bind_addresses'"
+                                 " argument".format(addr_kind))
+            else:
+                self.__setattr__('_{0}_binds'.format(addr_kind), [])
+                return
+        elif bind_address and bind_addresses:
+            raise ValueError("You can't use both '{0}_bind_address' and "
+                             "'{0}_bind_addresses' arguments. Use one of "
+                             "them.".format(addr_kind))
+        if bind_address:
+            self.__setattr__('_{0}_binds'.format(addr_kind), [bind_address])
+            return
+        self.__setattr__('_{0}_binds'.format(addr_kind), bind_addresses)
+
+    def _get_ssh_address_or_host(self, arg_name, kwargs):
+        """
+        Processes optional deprecate arguments to set up ssh_address_or_host
+        """
+        if arg_name in kwargs:
+            warnings.warn("'{0}' is DEPRECATED use 'ssh_address_or_host' or "
+                          "1st positional argument".format(arg_name),
+                          DeprecationWarning)
+            if self.ssh_address_or_host:
+                raise ValueError("You can't use both '{0}' and "
+                                 "'ssh_address_or_host'. Please only use one "
+                                 "of them".format(arg_name))
+            else:
+                self.ssh_address_or_host = kwargs.pop(arg_name)
 
     def start(self):
         if self._is_started:
             self.logger.warning("Already started!")
             return
-
         try:
-            if self._ssh_password:  # avoid conflict using both pass and pkey
-                self.logger.debug('Logging in with password {0}'
-                                  .format('*' * len(self._ssh_password)))
-                self._transport.connect(hostkey=self._ssh_host_key,
-                                        username=self._ssh_username,
-                                        password=self._ssh_password)
-            else:
-                self.logger.debug('Logging in with RSA key')
-                self._transport.connect(hostkey=self._ssh_host_key,
-                                        username=self._ssh_username,
-                                        pkey=self._ssh_private_key)
-
+            self._server_list = []  # reset server list
+            self.create_tunnels()
+            self._connect_to_gateway()
         except paramiko.ssh_exception.AuthenticationException:
             self.logger.error('Could not open connection to gateway')
             return
@@ -722,6 +736,20 @@ class SSHTunnelForwarder(object):
 
         if self.is_use_local_check_up:
             self.check_local_side_of_tunnels()
+
+    def _connect_to_gateway(self):
+        """Open connection to SSH gateway"""
+        if self.ssh_password:  # avoid conflict using both pass and pkey
+            self.logger.debug('Logging in with password {0}'
+                              .format('*' * len(self.ssh_password)))
+            self._transport.connect(hostkey=self.ssh_host_key,
+                                    username=self.ssh_username,
+                                    password=self.ssh_password)
+        else:
+            self.logger.debug('Logging in with RSA key')
+            self._transport.connect(hostkey=self.ssh_host_key,
+                                    username=self.ssh_username,
+                                    pkey=self.ssh_private_key)
 
     def check_local_side_of_tunnels(self):
         """
@@ -785,24 +813,29 @@ class SSHTunnelForwarder(object):
                             where 55550 and 55551 are the local bind ports
         """
         if self._is_started:
-
             self.logger.info('Closing all open connections...')
-            opened_address_text = ', '.join([address_to_str(k) for k, v
-                                             in self.tunnel_is_up.items()
-                                             if v]) \
-                                  or 'None'
-            self.logger.debug('Opened local addresses: ' + opened_address_text)
+            opened_address_text = ', '.join(
+                (address_to_str(k.local_address) for k in self._server_list)
+            ) or 'None'
+            self.logger.debug('Open local addresses: ' + opened_address_text)
 
             for _srv in self._server_list:
-                is_opened = _srv.local_address in self.tunnel_is_up if \
+                is_open = _srv.local_address in self.tunnel_is_up if \
                     self.is_use_local_check_up else True
-                local_address_text = address_to_str(_srv.local_address)
-                if is_opened:
-                    self.logger.info('Shutting down tunnel {0}'
-                                     .format(local_address_text))
+                if is_open:
+                    self.logger.info(
+                        'Shutting down tunnel {0}'.format(
+                            address_to_str(_srv.local_address)
+                        )
+                    )
                     _srv.shutdown()
                 _srv.server_close()
+        else:
+            self.logger.warning('Already stopped!')
+        self._stop_transport()
 
+    def _stop_transport(self):
+        """Close the underlying transport when nothing more is needed"""
         self._transport.close()
         self._transport.stop_thread()
         self.logger.debug('Transport is closed')

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -979,8 +979,8 @@ class SSHTunnelForwarder(object):
 
     def __enter__(self):
         self.start()
-        # if not self._is_started:
-        #     self.__exit__()
+        if not self._is_started:
+            self.stop()
         return self
 
     def __exit__(self, *args):

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -119,7 +119,7 @@ else:
     input_ = input
 
 
-__version__ = '0.0.6'
+__version__ = '0.0.7'
 __author__ = 'pahaz'
 
 __all__ = ('SSHTunnelForwarder', 'BaseSSHTunnelForwarderError',
@@ -691,7 +691,7 @@ class SSHTunnelForwarder(object):
             self.logger.debug('Connecting with ProxyCommand {0}'
                               .format(repr(self.ssh_proxy.cmd)))
             _socket = self.ssh_proxy
-            _socket.settimeout(SSH_TIMEOUT or 1.0)
+            _socket.settimeout(SSH_TIMEOUT)
         else:
             _socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             _socket.settimeout(SSH_TIMEOUT)

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -677,7 +677,7 @@ class SSHTunnelForwarder(object):
             self.logger.error(msg)
             raise BaseSSHTunnelForwarderError(msg)
         except socket.gaierror:  # raised by paramiko.Transport
-            msg = 'Could not resolve IP address for {}, aborting!' \
+            msg = 'Could not resolve IP address for {0}, aborting!' \
                 .format(ssh_host)
             self.logger.error(msg)
             raise BaseSSHTunnelForwarderError(msg)
@@ -686,7 +686,7 @@ class SSHTunnelForwarder(object):
             self.logger.error(msg)
             raise BaseSSHTunnelForwarderError(msg)
 
-        self.logger.debug('Concurrent connections allowed: {}'
+        self.logger.debug('Concurrent connections allowed: {0}'
                           .format(self._threaded))
         self._is_started = False
 
@@ -697,7 +697,7 @@ class SSHTunnelForwarder(object):
 
         try:
             if self._ssh_password:  # avoid conflict using both pass and pkey
-                self.logger.debug('Logging in with password {}'
+                self.logger.debug('Logging in with password {0}'
                                   .format('*' * len(self._ssh_password)))
                 self._transport.connect(hostkey=self._ssh_host_key,
                                         username=self._ssh_username,
@@ -805,7 +805,7 @@ class SSHTunnelForwarder(object):
                     self.is_use_local_check_up else True
                 local_address_text = address_to_str(_srv.local_address)
                 if is_opened:
-                    self.logger.info('Shutting down tunnel {}'
+                    self.logger.info('Shutting down tunnel {0}'
                                      .format(local_address_text))
                     _srv.shutdown()
                 _srv.server_close()
@@ -1080,7 +1080,9 @@ def main():
 
     PARSER.add_argument(
         '-v', '--verbosity', action='count', default=0,
-        help='Increase output verbosity (default: {})'.format(DEFAULT_LOGLEVEL)
+        help='Increase output verbosity (default: {0})'.format(
+            DEFAULT_LOGLEVEL
+        )
     )
 
     PARSER.add_argument(

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -641,7 +641,6 @@ class SSHTunnelForwarder(object):
         self.logger.info('Connecting to gateway: {0}:{1} as user "{2}".'
                          .format(ssh_host, ssh_port, ssh_username))
 
-        self.set_keepalive = set_keepalive
         # CREATE THE TUNNELS
         self.tunnel_is_up = {}  # handle status of the other side of the tunnel
         try:
@@ -651,7 +650,7 @@ class SSHTunnelForwarder(object):
                 self._transport = paramiko.Transport(ssh_proxy)
             else:
                 self._transport = paramiko.Transport((ssh_host, ssh_port))
-            self._transport.set_keepalive(self.set_keepalive)
+            self._transport.set_keepalive(set_keepalive)
             self._transport.daemon = self.daemon_transport
             for (rem, loc) in zip(remote_bind_addresses, local_bind_addresses):
                 ssh_forward_server = self.make_ssh_forward_server(rem, loc)

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -979,8 +979,6 @@ class SSHTunnelForwarder(object):
 
     def __enter__(self):
         self.start()
-        if not self._is_started:
-            self.stop()
         return self
 
     def __exit__(self, *args):

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -677,7 +677,7 @@ class SSHTunnelForwarder(object):
             self.logger.error(msg)
             raise BaseSSHTunnelForwarderError(msg)
         except socket.gaierror:  # raised by paramiko.Transport
-            msg = 'Could not resolve IP address for %s, aborting!' \
+            msg = 'Could not resolve IP address for {}, aborting!' \
                 .format(ssh_host)
             self.logger.error(msg)
             raise BaseSSHTunnelForwarderError(msg)
@@ -686,7 +686,8 @@ class SSHTunnelForwarder(object):
             self.logger.error(msg)
             raise BaseSSHTunnelForwarderError(msg)
 
-        self.logger.debug('Concurrent connections allowed: %s', self._threaded)
+        self.logger.debug('Concurrent connections allowed: {}'
+                          .format(self._threaded))
         self._is_started = False
 
     def start(self):
@@ -696,8 +697,8 @@ class SSHTunnelForwarder(object):
 
         try:
             if self._ssh_password:  # avoid conflict using both pass and pkey
-                self.logger.debug('Logging in with password %s',
-                                  '*' * len(self._ssh_password))
+                self.logger.debug('Logging in with password {}'
+                                  .format('*' * len(self._ssh_password)))
                 self._transport.connect(hostkey=self._ssh_host_key,
                                         username=self._ssh_username,
                                         password=self._ssh_password)
@@ -800,12 +801,12 @@ class SSHTunnelForwarder(object):
             self.logger.debug('Opened local addresses: ' + opened_address_text)
 
             for _srv in self._server_list:
-                is_opened = _srv.local_address in self.tunnel_is_up \
-                            if self.is_use_local_check_up else True
+                is_opened = _srv.local_address in self.tunnel_is_up if \
+                    self.is_use_local_check_up else True
                 local_address_text = address_to_str(_srv.local_address)
                 if is_opened:
-                    self.logger.info('Shutting down tunnel %s',
-                                     local_address_text)
+                    self.logger.info('Shutting down tunnel {}'
+                                     .format(local_address_text))
                     _srv.shutdown()
                 _srv.server_close()
 
@@ -1079,7 +1080,7 @@ def main():
 
     PARSER.add_argument(
         '-v', '--verbosity', action='count', default=0,
-        help='Increase output verbosity (default: %s)' % DEFAULT_LOGLEVEL
+        help='Increase output verbosity (default: {})'.format(DEFAULT_LOGLEVEL)
     )
 
     PARSER.add_argument(

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -718,9 +718,14 @@ class SSHTunnelForwarder(object):
         self._threads = threads
         self._is_started = True
 
-        if not self.is_use_local_check_up:
-            return
+        if self.is_use_local_check_up:
+            self.check_local_side_of_tunnels()
 
+    def check_local_side_of_tunnels(self):
+        """
+        Check the local side of the tunnels, updating self.tunnel_is_up with
+        the result of running self.local_is_up()
+        """
         for _srv in self._server_list:
             self.tunnel_is_up[_srv.local_address] = \
                 self.local_is_up(_srv.local_address)

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -641,6 +641,7 @@ class SSHTunnelForwarder(object):
         self.logger.info('Connecting to gateway: {0}:{1} as user "{2}".'
                          .format(ssh_host, ssh_port, ssh_username))
 
+        self.set_keepalive = set_keepalive
         # CREATE THE TUNNELS
         self.tunnel_is_up = {}  # handle status of the other side of the tunnel
         try:

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -1075,7 +1075,8 @@ def main():
     )
 
     PARSER.add_argument(
-        '-V', '--version', action='version', version='%(prog)s {version}'.format(version=__version__),
+        '-V', '--version', action='version',
+        version='%(prog)s {version}'.format(version=__version__),
         help='Show version number'
     )
 

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -97,7 +97,6 @@ optional arguments:
 
 """
 
-import sys
 import socket
 import getpass
 import logging
@@ -106,17 +105,11 @@ import warnings
 import threading
 from select import select
 from os.path import expanduser
+
 import paramiko
+from six import string_types
 
-if sys.version_info[0] < 3:
-    string_types = basestring,  # noqa
-else:
-    string_types = str
-
-if sys.version_info[0] < 3:
-    import SocketServer
-else:
-    import socketserver as SocketServer
+from six.moves import input, socketserver
 
 __version__ = '0.0.6'
 __author__ = 'pahaz'
@@ -247,7 +240,7 @@ class HandlerSSHTunnelForwarderError(BaseSSHTunnelForwarderError):
 ########################
 
 
-class _ForwardHandler(SocketServer.BaseRequestHandler):
+class _ForwardHandler(socketserver.BaseRequestHandler):
     """ Base handler for tunnel connections """
     remote_address = None
     ssh_transport = None
@@ -312,7 +305,7 @@ class _ForwardHandler(SocketServer.BaseRequestHandler):
             self.logger.info('{0} connection closed.'.format(info))
 
 
-class _ForwardServer(SocketServer.TCPServer):  # Not Threading
+class _ForwardServer(socketserver.TCPServer):  # Not Threading
     """
     Non-threading version of the forward server
     """
@@ -343,7 +336,7 @@ class _ForwardServer(SocketServer.TCPServer):  # Not Threading
         return self.RequestHandlerClass.remote_address[1]
 
 
-class _ThreadingForwardServer(SocketServer.ThreadingMixIn, _ForwardServer):
+class _ThreadingForwardServer(socketserver.ThreadingMixIn, _ForwardServer):
     """
     Allows concurrent connections to each tunnel
     """
@@ -425,9 +418,9 @@ class SSHTunnelForwarder(object):
         Make SSH Handler class.
         """
         _Handler = _ForwardHandler
-        if not issubclass(_Handler, SocketServer.BaseRequestHandler):
+        if not issubclass(_Handler, socketserver.BaseRequestHandler):
             msg = "base_ssh_forward_handler is not a subclass " \
-                  "SocketServer.BaseRequestHandler"
+                  "socketserver.BaseRequestHandler"
             raise BaseSSHTunnelForwarderError(msg)
 
         class Handler(_Handler):
@@ -1102,11 +1095,7 @@ def main():
         Press <Ctrl-C> or <Enter> to stop!
 
         ''')
-        if sys.version_info[0] < 3:
-            raw_input('')  # noqa
-        else:
-            input('')
-
+        input('')
 
 if __name__ == '__main__':
     main()

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -458,7 +458,6 @@ class SSHTunnelForwarder(object):
     def __init__(
             self,
             ssh_address_or_host=None,
-
             ssh_host_key=None,
             ssh_username=None,
             ssh_password=None,
@@ -470,7 +469,7 @@ class SSHTunnelForwarder(object):
             local_bind_address=None,
             remote_bind_addresses=None,
             local_bind_addresses=None,
-
+            set_keepalive=0,
             ssh_config_file="~/.ssh/config",
             logger=None,
             threaded=True,  # old version False
@@ -491,6 +490,7 @@ class SSHTunnelForwarder(object):
           threaded=True
           ssh_port=22
           ssh_host=None
+          set_keepalive=0,
           ssh_config_file=~/.ssh/config
           ssh_proxy=None
           ssh_proxy_enabled=True
@@ -650,6 +650,7 @@ class SSHTunnelForwarder(object):
                 self._transport = paramiko.Transport(ssh_proxy)
             else:
                 self._transport = paramiko.Transport((ssh_host, ssh_port))
+            self._transport.set_keepalive(self.set_keepalive)
             self._transport.daemon = self.daemon_transport
             for (rem, loc) in zip(remote_bind_addresses, local_bind_addresses):
                 ssh_forward_server = self.make_ssh_forward_server(rem, loc)
@@ -1070,6 +1071,11 @@ def main():
     PARSER.add_argument(
         '-v', '--verbosity', action='count', default=0,
         help='Increase output verbosity (default: %s)' % DEFAULT_LOGLEVEL
+    )
+
+    PARSER.add_argument(
+        '-V', '--version', action='version', version='%(prog)s {version}'.format(version=__version__),
+        help='Show version number'
     )
 
     args = vars(PARSER.parse_args())

--- a/tests/test_forwarder.py
+++ b/tests/test_forwarder.py
@@ -6,7 +6,6 @@ import select
 import socket
 import sys
 import threading
-import time
 import warnings
 
 import paramiko
@@ -202,7 +201,7 @@ class SSHClientTest(unittest.TestCase):
                 x.join()
                 self.log.info('thread {0} now stopped'.format(x))
 
-    def _run_ssh_server(self, delay=0):
+    def _run_ssh_server(self):
         self.socks, addr = self.ssockl.accept()
         self.ts = paramiko.Transport(self.socks)
         host_key = paramiko.RSAKey.from_private_key_file(
@@ -210,8 +209,6 @@ class SSHClientTest(unittest.TestCase):
         )
         self.ts.add_server_key(host_key)
         server = NullServer(allowed_keys=FINGERPRINTS.keys(), log=self.log)
-        if delay:
-            time.sleep(delay)
         t = threading.Thread(target=self._do_forwarding, name='ssh-forwarding')
         t.daemon = False
         self.threads.append(t)

--- a/tests/test_forwarder.py
+++ b/tests/test_forwarder.py
@@ -9,7 +9,6 @@ import threading
 import time
 import warnings
 
-import pytest
 import paramiko
 from os import path
 
@@ -464,8 +463,8 @@ class SSHClientTest(unittest.TestCase):
                 ssh_username=SSH_USERNAME
             )
 
-    @pytest.mark.skipif(sys.version_info < (2, 7),
-                        reason="Cannot intercept logging messages in py26")
+    @unittest.skipIf(sys.version_info < (2, 7),
+                     reason="Cannot intercept logging messages in py26")
     def test_reading_from_a_bad_sshconfigfile_does_not_raise_error(self):
         """
         Test that when a bad ssh_config file is found, a warning is shown
@@ -479,6 +478,7 @@ class SSHClientTest(unittest.TestCase):
             ssh_password=SSH_PASSWORD,
             remote_bind_address=(self.eaddr, self.eport),
             local_bind_address=('127.0.0.1', self.randomize_eport()),
+            logger=self.log,
             ssh_config_file=ssh_config_file
         )
         logged_message = 'Could not read SSH configuration file: {0}'.format(
@@ -496,7 +496,7 @@ class SSHClientTest(unittest.TestCase):
                 (self.saddr, self.sport),
                 ssh_username=SSH_USERNAME,
                 remote_bind_address=(self.eaddr, self.eport),
-                use_ssh_config=False
+                ssh_config_file=None
             )
 
     def test_deprecate_warnings_are_shown(self):
@@ -545,7 +545,7 @@ class SSHClientTest(unittest.TestCase):
                 ssh_username=SSH_USERNAME,
                 ssh_password=SSH_PASSWORD,
                 remote_bind_address=(self.eaddr, self.eport),
-                use_ssh_config=False
+                ssh_config_file=None
             )
             server.start()
             server.stop()
@@ -561,13 +561,13 @@ class SSHClientTest(unittest.TestCase):
                 ssh_username=SSH_USERNAME,
                 ssh_password=SSH_PASSWORD,
                 remote_bind_address=(self.eaddr, self.eport),
-                use_ssh_config=False
+                ssh_config_file=None
             )
             server.start()
             server.stop()
 
-    @pytest.mark.skipif(sys.version_info < (2, 7),
-                        reason="Cannot intercept logging messages in py26")
+    @unittest.skipIf(sys.version_info < (2, 7),
+                     reason="Cannot intercept logging messages in py26")
     def test_running_start_twice_logs_warning(self):
         """Test that when running start() twice a warning is shown"""
         server = SSHTunnelForwarder(
@@ -583,8 +583,8 @@ class SSHClientTest(unittest.TestCase):
         self.assertIn('Already started!',
                       self.sshtunnel_log_messages['warning'])
 
-    @pytest.mark.skipif(sys.version_info < (2, 7),
-                        reason="Cannot intercept logging messages in py26")
+    @unittest.skipIf(sys.version_info < (2, 7),
+                     reason="Cannot intercept logging messages in py26")
     def test_wrong_auth_to_gateway_logs_error(self):
         """
         Test that when connecting to the ssh gateway with wrong credentials,

--- a/tests/test_forwarder.py
+++ b/tests/test_forwarder.py
@@ -548,6 +548,7 @@ class SSHClientTest(unittest.TestCase):
                 use_ssh_config=False
             )
             server.start()
+            server.stop()
 
     def test_gateway_ip_unresolvable_raises_exception(self):
         """
@@ -563,6 +564,7 @@ class SSHClientTest(unittest.TestCase):
                 use_ssh_config=False
             )
             server.start()
+            server.stop()
 
     @pytest.mark.skipif(sys.version_info < (2, 7),
                         reason="Cannot intercept logging messages in py26")

--- a/tests/test_forwarder.py
+++ b/tests/test_forwarder.py
@@ -7,6 +7,7 @@ import socket
 import threading
 import time
 import unittest
+import warnings
 
 import paramiko
 from os import path
@@ -47,9 +48,7 @@ FINGERPRINTS = {
 }
 
 here = path.abspath(path.dirname(__file__))
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-log.addHandler(logging.StreamHandler())
+
 sshtunnel.TRACE = True
 
 
@@ -57,33 +56,64 @@ def get_test_data_path(x):
     return path.join(here, x)
 
 
+class MockLoggingHandler(logging.Handler):
+    """Mock logging handler to check for expected logs.
+
+    Messages are available from an instance's `messages` dict, in order,
+    indexed by a lowercase log level string (e.g., 'debug', 'info', etc.).
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.messages = {'debug': [], 'info': [], 'warning': [], 'error': [],
+                         'critical': []}
+        super(MockLoggingHandler, self).__init__(*args, **kwargs)
+
+    def emit(self, record):
+        "Store a message from ``record`` in the instance's ``messages`` dict."
+        self.acquire()
+        try:
+            self.messages[record.levelname.lower()].append(record.getMessage())
+        finally:
+            self.release()
+
+    def reset(self):
+        self.acquire()
+        try:
+            for message_list in self.messages:
+                self.messages[message_list] = []
+        finally:
+            self.release()
+
+
 class NullServer (paramiko.ServerInterface):
     def __init__(self, *args, **kwargs):
         # Allow tests to enable/disable specific key types
         self.__allowed_keys = kwargs.pop('allowed_keys', [])
+        self.log = kwargs.pop('log', sshtunnel.create_logger(loglevel='DEBUG'))
         super(NullServer, self).__init__(*args, **kwargs)
 
     def check_channel_forward_agent_request(self, channel):
-        log.debug('NullServer.check_channel_forward_agent_request() {0}'
-                  .format(channel))
+        self.log.debug('NullServer.check_channel_forward_agent_request() {0}'
+                       .format(channel))
         return False
 
     def get_allowed_auths(self, username):
-        log.debug('NullServer.get_allowed_auths() {0}'.format(repr(username)))
+        self.log.debug('NullServer.get_allowed_auths() %s',
+                       repr(username))
         if username == SSH_USERNAME:
             return 'publickey,password'
         return 'publickey'
 
     def check_auth_password(self, username, password):
-        log.debug('NullServer.check_auth_password() {0}'
-                  .format(repr(username)))
+        self.log.debug('NullServer.check_auth_password() {0}'
+                       .format(repr(username)))
         if username == SSH_USERNAME and password == SSH_PASSWORD:
             return paramiko.AUTH_SUCCESSFUL
         return paramiko.AUTH_FAILED
 
     def check_auth_publickey(self, username, key):
-        log.debug('NullServer.check_auth_publickey() {0}'
-                  .format(repr(username)))
+        self.log.debug('NullServer.check_auth_publickey() {0}'
+                       .format(repr(username)))
         try:
             expected = FINGERPRINTS[key.get_name()]
         except KeyError:
@@ -96,27 +126,29 @@ class NullServer (paramiko.ServerInterface):
         return paramiko.AUTH_FAILED
 
     def check_channel_request(self, kind, chanid):
-        log.debug('NullServer.check_channel_request()'.format(kind, chanid))
+        self.log.debug('NullServer.check_channel_request()'
+                       .format(kind, chanid))
         return paramiko.OPEN_SUCCEEDED
 
     def check_channel_exec_request(self, channel, command):
-        log.debug('NullServer.check_channel_exec_request()'
-                  .format(channel, command))
+        self.log.debug('NullServer.check_channel_exec_request()'
+                       .format(channel, command))
         return True
 
     def check_port_forward_request(self, address, port):
-        log.debug('NullServer.check_port_forward_request()'
-                  .format(address, port))
+        self.log.debug('NullServer.check_port_forward_request()'
+                       .format(address, port))
         return True
 
     def check_global_request(self, kind, msg):
-        log.debug('NullServer.check_port_forward_request()'.format(kind, msg))
+        self.log.debug('NullServer.check_port_forward_request()'
+                       .format(kind, msg))
         return True
 
     def check_channel_direct_tcpip_request(self, chanid, origin, destination):
-        log.debug('NullServer.check_channel_direct_tcpip_request(chanid={0}) '
-                  '{1} -> {2}'
-                  .format(chanid, origin, destination))
+        self.log.debug('NullServer.check_channel_direct_tcpip_request'
+                       '(chanid={0}) {1} -> {2}'
+                       .format(chanid, origin, destination))
         return paramiko.OPEN_SUCCEEDED
 
 
@@ -128,27 +160,37 @@ class SSHClientTest(unittest.TestCase):
         addr, port = s.getsockname()
         return s, addr, port
 
+    @classmethod
+    def setUpClass(cls):
+        super(SSHClientTest, cls).setUpClass()
+        cls.log = logging.getLogger(sshtunnel.__name__)
+        cls._sshtunnel_log_handler = MockLoggingHandler(level='DEBUG')
+        cls.log.addHandler(cls._sshtunnel_log_handler)
+        cls.sshtunnel_log_messages = cls._sshtunnel_log_handler.messages
+
     def setUp(self):
-        log.info('setUp()')
+        super(SSHClientTest, self).setUp()
+        self.log.info('setUp()')
         self.ssockl, self.saddr, self.sport = self.make_socket()
         self.esockl, self.eaddr, self.eport = self.make_socket()
-        log.info("Sockets for SSH server: {0}:{1}"
-                 .format(self.saddr, self.sport))
-        log.info("Sockets for ECHO server: {0}:{1}"
-                 .format(self.eaddr, self.eport))
+        self.log.info("Sockets for SSH server: {0}:{1}"
+                      .format(self.saddr, self.sport))
+        self.log.info("Sockets for ECHO server: {0}:{1}"
+                      .format(self.eaddr, self.eport))
         self.event = threading.Event()
         self.threads = []
         self.is_echo_server_working = False
+        self._sshtunnel_log_handler.reset()
 
     def tearDown(self):
-        log.info('tearDown()')
+        self.log.info('tearDown()')
         self.stop_echo_server()
         for attr in "server tc ts socks ssockl esockl".split():
             if hasattr(self, attr):
-                log.info('tearDown() {0}'.format(attr))
+                self.log.info('tearDown() {0}'.format(attr))
                 getattr(self, attr).close()
         for x in self.threads:
-            log.info('thread {0} - is_alive={1}'.format(x, x.is_alive()))
+            self.log.info('thread {0} - is_alive={1}'.format(x, x.is_alive()))
 
     def _run_ssh_server(self, delay=0):
         self.socks, addr = self.ssockl.accept()
@@ -157,7 +199,7 @@ class SSHClientTest(unittest.TestCase):
             get_test_data_path('testrsa.key')
         )
         self.ts.add_server_key(host_key)
-        server = NullServer(allowed_keys=FINGERPRINTS.keys())
+        server = NullServer(allowed_keys=FINGERPRINTS.keys(), log=self.log)
         if delay:
             time.sleep(delay)
         t = threading.Thread(target=self._do_forwarding, name='ssh-forwarding')
@@ -178,7 +220,7 @@ class SSHClientTest(unittest.TestCase):
     def _run_echo_server(self):
         socks = [self.esockl]
         self.is_echo_server_working = True
-        log.info('ECHO RUN on {0}'.format(self.esockl.getsockname()))
+        self.log.info('ECHO RUN on {0}'.format(self.esockl.getsockname()))
         try:
             while self.is_echo_server_working:
                 inputready, _, _ = select.select(socks, [], [], 10)
@@ -187,35 +229,36 @@ class SSHClientTest(unittest.TestCase):
                         # handle the server socket
                         try:
                             client, address = self.esockl.accept()
-                            log.info('ECHO accept() {0}'.format(address))
+                            self.log.info('ECHO accept() {0}'.format(address))
                         except OSError:
-                            log.info('ECHO accept() OSError')
+                            self.log.info('ECHO accept() OSError')
                             break
                         socks.append(client)
                     else:
                         # handle all other sockets
                         try:
                             data = s.recv(1000)
-                            log.info('ECHO recv({0}) send({0})'.format(data))
+                            self.log.info('ECHO recv({0}) send(%s)',
+                                          data)
                             s.send(data)
                         except OSError:
-                            log.warning('ECHO OSError')
+                            self.log.warning('ECHO OSError')
                             continue
                         finally:
                             s.close()
                             socks.remove(s)
         except Exception as e:
-            log.info('ECHO except {0}'.format(repr(e)))
+            self.log.info('ECHO except {0}'.format(repr(e)))
         finally:
             self.is_echo_server_working = False
             for s in socks:
                 s.close()
-            log.info('ECHO down')
+            self.log.info('ECHO down')
 
     def _do_forwarding(self, timeout=None):
         schan = self.ts.accept(timeout=timeout)
         info = "FORWARDING schan <> echo"
-        log.info(info + " accept()")
+        self.log.info(info + " accept()")
         echo = socket.create_connection(
             (self.eaddr, self.eport)
         )
@@ -224,13 +267,13 @@ class SSHClientTest(unittest.TestCase):
                 rqst, _, _ = select.select([schan, echo], [], [], 10)
                 if schan in rqst:
                     data = schan.recv(1024)
-                    log.debug('{0} -->: {1}'.format(info, repr(data)))
+                    self.log.debug('{0} -->: {1}'.format(info, repr(data)))
                     echo.send(data)
                     if len(data) == 0:
                         break
                 if echo in rqst:
                     data = echo.recv(1024)
-                    log.debug('{0} <--: {1}'.format(info, repr(data)))
+                    self.log.debug('{0} <--: {1}'.format(info, repr(data)))
                     schan.send(data)
                     if len(data) == 0:
                         break
@@ -239,13 +282,14 @@ class SSHClientTest(unittest.TestCase):
             # exception. It was seen that a 3way FIN is processed later on, so
             # no need to make an ordered close of the connection here or raise
             # the exception beyond this point...
-            log.warning('{0} sending RST'.format(info))
+            self.log.warning('{0} sending RST'.format(info))
         except Exception as e:
-            log.error('{0} error: {1}'.format(info, repr(e)))
+            self.log.error('{0} error: {1}'.format(info, repr(e)))
         finally:
-            schan.close()
+            if schan:
+                schan.close()
             echo.close()
-            log.debug('{0} connection closed.'.format(info))
+            self.log.debug('{0} connection closed.'.format(info))
 
     def _run_echo_and_ssh(self, server):
         self.start_echo_server()
@@ -266,15 +310,17 @@ class SSHClientTest(unittest.TestCase):
         self.assertEqual(SSH_USERNAME, self.ts.get_username())
         self.assertEqual(True, self.ts.is_authenticated())
 
+    def randomize_eport(self):
+        return self.eport + random.randint(1, 999)
+
     def test_connect_by_username_password(self):
         server = SSHTunnelForwarder(
             (self.saddr, self.sport),
             ssh_username=SSH_USERNAME,
             ssh_password=SSH_PASSWORD,
             remote_bind_address=(self.eaddr, self.eport),
-            logger=log,
+            logger=self.log,
         )
-
         self._test_server(server)
 
     def test_connect_by_rsa_key(self):
@@ -283,7 +329,7 @@ class SSHClientTest(unittest.TestCase):
             ssh_username=SSH_USERNAME,
             ssh_private_key=get_test_data_path('testrsa.key'),
             remote_bind_address=(self.eaddr, self.eport),
-            logger=log,
+            logger=self.log,
         )
 
         self._test_server(server)
@@ -292,12 +338,247 @@ class SSHClientTest(unittest.TestCase):
         self._run_echo_and_ssh(server)
         MESSAGE = get_random_string().encode()
         LOCAL_BIND_ADDR = ('127.0.0.1', self.server.local_bind_port)
-        log.info('_test_server(): try connect!')
+        self.log.info('_test_server(): try connect!')
         s = socket.create_connection(LOCAL_BIND_ADDR)
-        log.info('_test_server(): connected from {0}! try send!'
-                 .format(s.getsockname()))
+        self.log.info('_test_server(): connected from {0}! try send!'
+                      .format(s.getsockname()))
         s.send(MESSAGE)
-        log.info('_test_server(): sent!')
+        self.log.info('_test_server(): sent!')
         z = (s.recv(1000))
         self.assertEqual(z, MESSAGE)
         s.close()
+
+    def test_sshaddress_and_sshaddresssorhost_mutually_exclusive(self):
+        """
+        Test that deprecate argument ssh_address cannot be used together with
+        ssh_address_or_host
+        """
+        with self.assertRaises(ValueError):
+            SSHTunnelForwarder(
+                ssh_address_or_host=(self.saddr, self.sport),
+                ssh_address=(self.saddr, self.sport),
+                ssh_username=SSH_USERNAME,
+                ssh_password=SSH_PASSWORD,
+                remote_bind_address=(self.eaddr, self.eport),
+            )
+
+    def test_sshhost_and_sshaddresssorhost_mutually_exclusive(self):
+        """
+        Test that deprecate argument ssh_host cannot be used together with
+        ssh_address_or_host
+        """
+        with self.assertRaises(ValueError):
+            SSHTunnelForwarder(
+                (self.saddr, self.sport),  # as 1st positional argument
+                ssh_host=(self.saddr, self.sport),
+                ssh_username=SSH_USERNAME,
+                ssh_password=SSH_PASSWORD,
+                remote_bind_address=(self.eaddr, self.eport),
+            )
+
+    def test_sshaddressorhost_may_not_be_a_tuple(self):
+        """
+        Test that when ssh_address_or_host contains just the address part
+        (and not the port), we'll look at the contents of ssh_port (if any)
+        """
+        server = SSHTunnelForwarder(
+            self.saddr,
+            ssh_username=SSH_USERNAME,
+            ssh_password=SSH_PASSWORD,
+            remote_bind_address=(self.eaddr, self.eport),
+        )
+        self.assertEqual(server._transport.getpeername()[1], 22)
+
+    def test_unknown_argument_raises_exception(self):
+        """Test that an exception is raised when setting an invalid argument"""
+        with self.assertRaises(ValueError):
+            SSHTunnelForwarder(
+                self.saddr,
+                ssh_username=SSH_USERNAME,
+                ssh_password=SSH_PASSWORD,
+                remote_bind_address=(self.eaddr, self.eport),
+                i_do_not_exist=0
+            )
+
+    def test_more_local_than_remote_bind_sizes_raise_exception(self):
+        """
+        Test that when the number of local_bind_addresses exceed number of
+        remote_bind_addresses, an exception is raised
+        """
+        with self.assertRaises(ValueError):
+            SSHTunnelForwarder(
+                self.saddr,
+                ssh_username=SSH_USERNAME,
+                ssh_password=SSH_PASSWORD,
+                remote_bind_address=(self.eaddr, self.eport),
+                local_bind_addresses=[('127.0.0.1', self.eport),
+                                      ('127.0.0.1', self.randomize_eport())]
+             )
+
+    def test_localbindaddress_and_localbindaddresses_mutually_exclusive(self):
+        """
+        Test that arguments local_bind_address and local_bind_addresses cannot
+        be used together
+        """
+        with self.assertRaises(ValueError):
+            SSHTunnelForwarder(
+                (self.saddr, self.sport),
+                ssh_username=SSH_USERNAME,
+                ssh_password=SSH_PASSWORD,
+                remote_bind_address=(self.eaddr, self.eport),
+                local_bind_address=('127.0.0.1', self.eport),
+                local_bind_addresses=[('127.0.0.1', self.eport),
+                                      ('127.0.0.1', self.randomize_eport())]
+            )
+
+    def test_remotebindaddress_and_remotebindaddresses_are_exclusive(self):
+        """
+        Test that arguments remote_bind_address and remote_bind_addresses
+        cannot be used together
+        """
+        with self.assertRaises(ValueError):
+            SSHTunnelForwarder(
+                (self.saddr, self.sport),
+                ssh_username=SSH_USERNAME,
+                ssh_password=SSH_PASSWORD,
+                remote_bind_address=(self.eaddr, self.eport),
+                remote_bind_addresses=[(self.eaddr, self.eport),
+                                       (self.eaddr, self.randomize_eport())]
+            )
+
+    def test_no_remote_bind_address_raises_exception(self):
+        """
+        When no remote_bind_address or remote_bind_addresses are specified, a
+        ValueError exception should be raised
+        """
+        with self.assertRaises(ValueError):
+            SSHTunnelForwarder(
+                (self.saddr, self.sport),
+                ssh_username=SSH_USERNAME,
+                use_ssh_config=False
+            )
+
+    def test_reading_from_a_bad_sshconfigfile_does_not_raise_error(self):
+        """
+        Test that when a bad ssh_config file is found, a warning is shown
+        but no exception is raised
+        """
+        ssh_config_file = 'not_existing_file'
+
+        SSHTunnelForwarder(
+            (self.saddr, self.sport),
+            ssh_username=SSH_USERNAME,
+            ssh_password=SSH_PASSWORD,
+            remote_bind_address=(self.eaddr, self.eport),
+            local_bind_address=('127.0.0.1', self.randomize_eport()),
+            ssh_config_file=ssh_config_file
+        )
+        logged_message = 'Could not read SSH configuration file: {}'.format(
+                             ssh_config_file
+                         )
+        self.assertIn(logged_message, self.sshtunnel_log_messages['warning'])
+
+    def test_not_setting_password_or_pkey_raises_error(self):
+        """
+        Test that when a no authentication method is specified, an exception is
+        raised
+        """
+        with self.assertRaises(ValueError):
+            SSHTunnelForwarder(
+                (self.saddr, self.sport),
+                ssh_username=SSH_USERNAME,
+                remote_bind_address=(self.eaddr, self.eport),
+                use_ssh_config=False
+            )
+
+    def test_deprecate_warnings_are_shown(self):
+        """Test that when using deprecate arguments a warning is logged"""
+        warnings.simplefilter("always")  # don't ignore DeprecationWarnings
+        with warnings.catch_warnings(record=True) as w:
+            for deprecated_arg in ['ssh_address', 'ssh_host']:
+                eval(
+                    SSHTunnelForwarder.__name__ + '({}={})'.format(
+                        deprecated_arg,
+                        '(self.saddr, self.sport),'
+                        'ssh_username=SSH_USERNAME,'
+                        'ssh_password=SSH_PASSWORD,'
+                        'remote_bind_address=(self.eaddr, self.eport)'
+                    )
+                )
+                logged_message = "'{}' is DEPRECATED use " \
+                                 "'ssh_address_or_host' or 1st positional " \
+                                 "argument".format(deprecated_arg)
+                self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+                self.assertEqual(logged_message, w[-1].message.message)
+
+            with self.assertRaises(NotImplementedError):
+                sshtunnel.make_ssh_forward_server('remote_address',
+                                                  'local_bind_address',
+                                                  'ssh_transport')
+                self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+                self.assertEqual(logged_message, w[-1].message.message)
+
+            with self.assertRaises(NotImplementedError):
+                sshtunnel.make_ssh_forward_handler('remote_address',
+                                                   'ssh_transport')
+                self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+                self.assertEqual(logged_message, w[-1].message.message)
+
+    def test_gateway_unreachable_raises_exception(self):
+        """
+        BaseSSHTunnelForwarderError is raised when not able to reach the
+        ssh gateway
+        """
+        with self.assertRaises(sshtunnel.BaseSSHTunnelForwarderError):
+            SSHTunnelForwarder(
+                (self.saddr, self.randomize_eport()),
+                ssh_username=SSH_USERNAME,
+                ssh_password=SSH_PASSWORD,
+                remote_bind_address=(self.eaddr, self.eport),
+                use_ssh_config=False
+            )
+
+    def test_gateway_ip_unresolvable_raises_exception(self):
+        """
+        BaseSSHTunnelForwarderError is raised when not able to resolve the
+        ssh gateway IP address
+        """
+        with self.assertRaises(sshtunnel.BaseSSHTunnelForwarderError):
+            SSHTunnelForwarder(
+                (SSH_USERNAME, self.sport),
+                ssh_username=SSH_USERNAME,
+                ssh_password=SSH_PASSWORD,
+                remote_bind_address=(self.eaddr, self.eport),
+                use_ssh_config=False
+            )
+
+    def test_running_start_twice_logs_warning(self):
+        """Test that when running start() twice a warning is shown"""
+        server = SSHTunnelForwarder(
+            (self.saddr, self.sport),
+            ssh_username=SSH_USERNAME,
+            ssh_password=SSH_PASSWORD,
+            remote_bind_address=(self.eaddr, self.eport)
+        )
+        self._test_server(server)
+        self.assertNotIn('Already started!',
+                         self.sshtunnel_log_messages['warning'])
+        server.start()  # 2nd start should prompt the warning
+        self.assertIn('Already started!',
+                      self.sshtunnel_log_messages['warning'])
+
+    def test_wrong_auth_to_gateway_logs_error(self):
+        """
+        Test that when connecting to the ssh gateway with wrong credentials,
+        an error is logged
+        """
+        with self.assertRaises(AssertionError):
+            server = SSHTunnelForwarder(
+                (self.saddr, self.sport),
+                ssh_username=SSH_USERNAME,
+                ssh_password=SSH_PASSWORD[::-1],
+                remote_bind_address=(self.eaddr, self.randomize_eport())
+            )
+            self._test_server(server)
+            self.assertIn('Could not open connection to gateway',
+                          self.sshtunnel_log_messages['error'])

--- a/tests/test_forwarder.py
+++ b/tests/test_forwarder.py
@@ -52,9 +52,9 @@ FINGERPRINTS = {
     'ecdsa-sha2-nistp256': ECDSA,
 }
 
-DAEMON_THREADS = True
+DAEMON_THREADS = False
 HERE = path.abspath(path.dirname(__file__))
-sshtunnel.TRACE = False
+sshtunnel.TRACE = True
 sshtunnel.SSH_TIMEOUT = 1.0
 
 

--- a/tests/test_forwarder.py
+++ b/tests/test_forwarder.py
@@ -197,6 +197,10 @@ class SSHClientTest(unittest.TestCase):
                 getattr(self, attr).close()
         for x in self.threads:
             self.log.info('thread {0} - is_alive={1}'.format(x, x.is_alive()))
+        for x in self.threads:
+            if x.is_alive():
+                x.join()
+                self.log.info('thread {0} now stopped'.format(x))
 
     def _run_ssh_server(self, delay=0):
         self.socks, addr = self.ssockl.accept()

--- a/tests/test_forwarder.py
+++ b/tests/test_forwarder.py
@@ -230,7 +230,7 @@ class SSHClientTest(unittest.TestCase):
         self.log.info('ECHO RUN on {0}'.format(self.esockl.getsockname()))
         try:
             while self.is_echo_server_working:
-                inputready, _, _ = select.select(socks, [], [], 10)
+                inputready, _, _ = select.select(socks, [], [], 1.0)
                 for s in inputready:
                     if s == self.esockl:
                         # handle the server socket
@@ -394,7 +394,7 @@ class SSHClientTest(unittest.TestCase):
             ssh_password=SSH_PASSWORD,
             remote_bind_address=(self.eaddr, self.eport),
         )
-        self.assertEqual(server._transport.getpeername()[1], 22)
+        self.assertEqual(server.ssh_port, 22)
 
     def test_unknown_argument_raises_exception(self):
         """Test that an exception is raised when setting an invalid argument"""
@@ -407,7 +407,7 @@ class SSHClientTest(unittest.TestCase):
                 i_do_not_exist=0
             )
 
-    def test_more_local_than_remote_bind_sizes_raise_exception(self):
+    def test_more_local_than_remote_bind_sizes_raises_exception(self):
         """
         Test that when the number of local_bind_addresses exceed number of
         remote_bind_addresses, an exception is raised
@@ -499,8 +499,6 @@ class SSHClientTest(unittest.TestCase):
                 use_ssh_config=False
             )
 
-    @pytest.mark.skipif(sys.version_info[0] == 3,
-                        reason="'ResourceWarning: unclosed' on py3")
     def test_deprecate_warnings_are_shown(self):
         """Test that when using deprecate arguments a warning is logged"""
         warnings.simplefilter("always")  # don't ignore DeprecationWarnings
@@ -542,13 +540,14 @@ class SSHClientTest(unittest.TestCase):
         ssh gateway
         """
         with self.assertRaises(sshtunnel.BaseSSHTunnelForwarderError):
-            SSHTunnelForwarder(
+            server = SSHTunnelForwarder(
                 (self.saddr, self.randomize_eport()),
                 ssh_username=SSH_USERNAME,
                 ssh_password=SSH_PASSWORD,
                 remote_bind_address=(self.eaddr, self.eport),
                 use_ssh_config=False
             )
+            server.start()
 
     def test_gateway_ip_unresolvable_raises_exception(self):
         """
@@ -556,13 +555,14 @@ class SSHClientTest(unittest.TestCase):
         ssh gateway IP address
         """
         with self.assertRaises(sshtunnel.BaseSSHTunnelForwarderError):
-            SSHTunnelForwarder(
+            server = SSHTunnelForwarder(
                 (SSH_USERNAME, self.sport),
                 ssh_username=SSH_USERNAME,
                 ssh_password=SSH_PASSWORD,
                 remote_bind_address=(self.eaddr, self.eport),
                 use_ssh_config=False
             )
+            server.start()
 
     @pytest.mark.skipif(sys.version_info < (2, 7),
                         reason="Cannot intercept logging messages in py26")

--- a/tests/test_forwarder.py
+++ b/tests/test_forwarder.py
@@ -413,7 +413,7 @@ class SSHClientTest(unittest.TestCase):
                 remote_bind_address=(self.eaddr, self.eport),
                 local_bind_addresses=[('127.0.0.1', self.eport),
                                       ('127.0.0.1', self.randomize_eport())]
-             )
+            )
 
     def test_localbindaddress_and_localbindaddresses_mutually_exclusive(self):
         """
@@ -454,8 +454,7 @@ class SSHClientTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             SSHTunnelForwarder(
                 (self.saddr, self.sport),
-                ssh_username=SSH_USERNAME,
-                use_ssh_config=False
+                ssh_username=SSH_USERNAME
             )
 
     def test_reading_from_a_bad_sshconfigfile_does_not_raise_error(self):
@@ -474,8 +473,8 @@ class SSHClientTest(unittest.TestCase):
             ssh_config_file=ssh_config_file
         )
         logged_message = 'Could not read SSH configuration file: {}'.format(
-                             ssh_config_file
-                         )
+            ssh_config_file
+        )
         self.assertIn(logged_message, self.sshtunnel_log_messages['warning'])
 
     def test_not_setting_password_or_pkey_raises_error(self):
@@ -496,15 +495,11 @@ class SSHClientTest(unittest.TestCase):
         warnings.simplefilter("always")  # don't ignore DeprecationWarnings
         with warnings.catch_warnings(record=True) as w:
             for deprecated_arg in ['ssh_address', 'ssh_host']:
-                eval(
-                    SSHTunnelForwarder.__name__ + '({}={})'.format(
-                        deprecated_arg,
-                        '(self.saddr, self.sport),'
-                        'ssh_username=SSH_USERNAME,'
-                        'ssh_password=SSH_PASSWORD,'
-                        'remote_bind_address=(self.eaddr, self.eport)'
-                    )
-                )
+                _kwargs = {deprecated_arg: (self.saddr, self.sport),
+                           'ssh_username': SSH_USERNAME,
+                           'ssh_password': SSH_PASSWORD,
+                           'remote_bind_address': (self.eaddr, self.eport)}
+                SSHTunnelForwarder(**_kwargs)
                 logged_message = "'{}' is DEPRECATED use " \
                                  "'ssh_address_or_host' or 1st positional " \
                                  "argument".format(deprecated_arg)
@@ -580,5 +575,5 @@ class SSHClientTest(unittest.TestCase):
                 remote_bind_address=(self.eaddr, self.randomize_eport())
             )
             self._test_server(server)
-            self.assertIn('Could not open connection to gateway',
-                          self.sshtunnel_log_messages['error'])
+        self.assertIn('Could not open connection to gateway',
+                      self.sshtunnel_log_messages['error'])

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@
 #  and also to help confirm pull requests to this project.
 
 [tox]
-envlist = py{26,27,33,34}
+envlist = py{26,27,33,34,35}
 
 [testenv]
 basepython =
@@ -19,6 +19,7 @@ basepython =
     py27: python2.7
     py33: python3.3
     py34: python3.4
+    py35: python3.5
 deps =
     check-manifest
     {py27,py33,py34}: readme

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ basepython =
 deps =
     check-manifest
     {py27,py33,py34}: readme
+    {py26}: unittest2
     flake8
     pytest
     pytest-cov


### PR DESCRIPTION
Since the addition of `is_use_local_check_up` parameter in 64af238 the default behaviour is not to check the local side of the tunnel.
I see here two issues:
- Being not backwards compatible with versions prior to 0.0.5 (which may be a decision made by @pahaz which I respect)
- Not being able to set directly the way we want it to behave. Now we've first to create an `SSHTunnelForwarder` object, then change its `is_use_local_check_up` value to `True`.

I added a new method for `SSHTunnelForwarder` to force those checks.
