### PR TITLE
Support paramiko PKey as ssh_private_key

### DIFF
--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -610,14 +610,15 @@ class SSHTunnelForwarder(object):
                                 .format(ssh_config_file))
 
         if not ssh_password:
-            ssh_private_key = paramiko.RSAKey.from_private_key_file(
-                ssh_private_key,
-                password=ssh_private_key_password
-            ) if ssh_private_key else None
-
             # Check if a private key was supplied or found in ssh_config
             if not ssh_private_key:
                 raise ValueError('No password or private key available!')
+
+            if isinstance(ssh_private_key, string_types):
+                ssh_private_key = paramiko.RSAKey.from_private_key_file(
+                    ssh_private_key,
+                    password=ssh_private_key_password
+                )
 
         if not ssh_port:
             ssh_port = 22

--- a/tests/test_forwarder.py
+++ b/tests/test_forwarder.py
@@ -277,11 +277,24 @@ class SSHClientTest(unittest.TestCase):
 
         self._test_server(server)
 
-    def test_connect_by_rsa_key(self):
+    def test_connect_by_rsa_key_file(self):
         server = SSHTunnelForwarder(
             (self.saddr, self.sport),
             ssh_username=SSH_USERNAME,
             ssh_private_key=get_test_data_path('testrsa.key'),
+            remote_bind_address=(self.eaddr, self.eport),
+            logger=log,
+        )
+
+        self._test_server(server)
+
+    def test_connect_by_paramiko_key(self):
+        ssh_key = paramiko.RSAKey.from_private_key_file(
+            get_test_data_path('testrsa.key'))
+        server = SSHTunnelForwarder(
+            (self.saddr, self.sport),
+            ssh_username=SSH_USERNAME,
+            ssh_private_key=ssh_key,
             remote_bind_address=(self.eaddr, self.eport),
             logger=log,
         )


### PR DESCRIPTION
The previous implementation always assumed the passed `ssh_private_key` was a filename. This checks this assumption, so you can also pass already parsed keys.