### PR TITLE
point to existent entry point func, _cli_main

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ setup(
     # pip to create the appropriate form of executable for the target platform.
     entry_points={
         'console_scripts': [
-            'sshtunnel=sshtunnel:main',
+            'sshtunnel=sshtunnel:_cli_main',
         ]
     },
 


### PR DESCRIPTION
The console entry point was expecting a
callable called 'main' in sshtunnel.py,
but the function name is actually
`_cli_main`

Fixes #53 