### PR TITLE
added case for OSX instance gaierror

### DIFF
--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -24,6 +24,8 @@ from select import select
 
 import paramiko
 
+from socket import gaierror
+
 if sys.version_info[0] < 3:  # pragma: no cover
     import SocketServer as socketserver
     string_types = basestring,  # noqa
@@ -1375,7 +1377,11 @@ class SSHTunnelForwarder(object):
         """
         Return all local network interface's IP addresses
         """
-        local_if = socket.gethostbyname_ex(socket.gethostname())[-1]
+        try:
+            local_if = socket.gethostbyname_ex(socket.gethostname())[-1]
+        except gaierror:
+            #used for OSX instances that don't include local in their hostname
+            local_if = socket.gethostbyname_ex("{}.local".format(socket.gethostname()))[-1]
         # In Linux, if /etc/hosts is populated with the hostname, it will only
         # return 127.0.0.1
         if '127.0.0.1' not in local_if:


### PR DESCRIPTION
Thanks for making paramiko so much easier to use! :D

On my OSX instance, socket.gethostname() does not return an extension, so socket.gethostbyname_ex doesn't work. There may be others with the same problem, so I followed this random stranger's [advice](https://bugs.launchpad.net/expel/+bug/903810 "advice") and it works now. Hope it's good to merge and pip, let me know what you think.