### PR TITLE
Handle exceptions while creating forward server more gracefully.

### DIFF
--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -1079,7 +1079,9 @@ class SSHTunnelForwarder(object):
             try:
                 self._make_ssh_forward_server(rem, loc)
             except BaseSSHTunnelForwarderError as e:
-                msg = 'Problem setting SSH Forwarder up: {0}'.format(e.args[0])
+                if self._transport is not None:
+                    self._transport.close()
+                msg = 'Problem setting SSH Forwarder up: {0}'.format(e.value)
                 self.logger.error(msg)
 
     @staticmethod


### PR DESCRIPTION
This fixes a couple bugs I ran into while trying to debug error handling around failed SSH connections in an application that uses sshtunnel.

* Fixes bug generating error log after catching a
  BaseSSHTunnelForwarderError.
* Closes open SSH connection after a BaseSSHTunnelForwarderError that
  otherwise would leave an unjoined thread running, preventing applications from exiting.