### PR TITLE
Path to private key expanded to set the absolute path when the user home shortcut is used

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,5 @@
 |CircleCI| |AppVeyor| |readthedocs| |coveralls| |version|
 
-|DwnMonth| |DwnWeek| |DwnDay|
-
 |pyversions| |license|
 
 **Author**: `Pahaz Blinov`_
@@ -243,9 +241,6 @@ CLI usage
    :alt: Documentation Status
 .. |coveralls| image:: https://coveralls.io/repos/github/pahaz/sshtunnel/badge.svg?branch=master
    :target: https://coveralls.io/github/pahaz/sshtunnel?branch=master
-.. |DwnMonth| image:: https://img.shields.io/pypi/dm/sshtunnel.svg
-.. |DwnWeek| image:: https://img.shields.io/pypi/dw/sshtunnel.svg
-.. |DwnDay| image:: https://img.shields.io/pypi/dd/sshtunnel.svg
 .. |pyversions| image:: https://img.shields.io/pypi/pyversions/sshtunnel.svg
 .. |version| image:: https://img.shields.io/pypi/v/sshtunnel.svg
    :target: `sshtunnel`_

--- a/changelog.rst
+++ b/changelog.rst
@@ -10,10 +10,13 @@ CONTRIBUTORS
 - `Mart Sõmermaa`_
 - `Chronial`_
 - `Dan Harbin`_
+- `Ignacio Peluffo`_
 
 CHANGELOG
 =========
 
+- v.0.1.3 (`Ignacio Peluffo`_)
+    + ``pkey_file`` parameter updated to accept relative paths to user folder using ``~``
 - v.0.1.2 (`JM Fernández`_)
     + Fix #77
 - v.0.1.1 (`JM Fernández`_)
@@ -104,6 +107,7 @@ CHANGELOG
 .. _Mart Sõmermaa: https://github.com/mrts
 .. _Chronial: https://github.com/Chronial
 .. _Dan Harbin: https://github.com/RasterBurn
+.. _Ignacio Peluffo: https://github.com/ipeluffo
 .. _#13: https://github.com/pahaz/sshtunnel/issues/13
 .. _#16: https://github.com/pahaz/sshtunnel/issues/16
 .. _#19: https://github.com/pahaz/sshtunnel/issues/19

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -1015,9 +1015,10 @@ class SSHTunnelForwarder(object):
             ssh_loaded_pkeys = []
 
         if isinstance(ssh_pkey, string_types):
-            if os.path.exists(ssh_pkey):
+            ssh_pkey_expanded = os.path.expanduser(ssh_pkey)
+            if os.path.exists(ssh_pkey_expanded):
                 ssh_pkey = SSHTunnelForwarder.read_private_key_file(
-                    pkey_file=ssh_pkey,
+                    pkey_file=ssh_pkey_expanded,
                     pkey_password=ssh_pkey_password or ssh_password,
                     logger=logger
                 )


### PR DESCRIPTION
Python os library doesn't check when the User home shortcut (`~`) is used in a path.

This PR changes the logic to expand the path to the real absolute path before checking the existence of the private key file.

Example of the behavior mentioned above:
```
In [1]: import os

In [2]: os.path.exists('~/.ssh/id_rsa')
Out[2]: False

In [3]: os.path.exists('/Users/ipeluffo/.ssh/id_rsa')
Out[3]: True

In [4]: os.path.exists(os.path.expanduser('~/.ssh/id_rsa'))
Out[4]: True
```