### PR TITLE
Fix #110, add support for py36

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,6 @@ machine:
   environment:
     CIRCLE_BUILD_IMAGE: ubuntu-14.04
     TOX_PY27: '2.7.12'
-    TOX_PY33: '3.3.6'
     TOX_PY34: '3.4.4'
     TOX_PY35: '3.5.3'
     TOX_PY36: '3.6.2'
@@ -15,7 +14,7 @@ dependencies:
     - pip install --upgrade tox
     - pip install --upgrade tox-pyenv
     - pip install coveralls
-    - pyenv local $TOX_PY36 $TOX_PY35 $TOX_PY34 $TOX_PY33 $TOX_PY27
+    - pyenv local $TOX_PY36 $TOX_PY35 $TOX_PY34 $TOX_PY27
     - pip install --upgrade bashtest
     - python setup.py install
     - bashtest README*

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,10 @@
 machine:
   environment:
-    TOX_PY26: '2.6.8'
-    TOX_PY27: '2.7.10'
-    TOX_PY33: '3.3.3'
-    TOX_PY34: '3.4.3'
-    TOX_PY35: '3.5.0'
+    TOX_PY27: '2.7.12'
+    TOX_PY33: '3.3.6'
+    TOX_PY34: '3.4.4'
+    TOX_PY35: '3.5.3'
+    TOX_PY36: '3.6.2'
 
 dependencies:
   override:
@@ -14,7 +14,7 @@ dependencies:
     - pip install --upgrade tox
     - pip install --upgrade tox-pyenv
     - pip install coveralls
-    - pyenv local $TOX_PY35 $TOX_PY34 $TOX_PY33 $TOX_PY27 $TOX_PY26
+    - pyenv local $TOX_PY36 $TOX_PY35 $TOX_PY34 $TOX_PY33 $TOX_PY27
     - pip install --upgrade bashtest
     - python setup.py install
     - bashtest README*

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 machine:
   environment:
+    CIRCLE_BUILD_IMAGE: ubuntu-14.04
     TOX_PY27: '2.7.12'
     TOX_PY33: '3.3.6'
     TOX_PY34: '3.4.4'

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -1185,7 +1185,9 @@ class SSHTunnelForwarder(object):
         s.settimeout(TUNNEL_TIMEOUT)
         try:
             # Windows raises WinError 10049 if trying to connect to 0.0.0.0
-            s.connect(('127.0.0.1', _srv.local_port))
+            connect_to = ('127.0.0.1', _srv.local_port) \
+                if _srv.local_host == '0.0.0.0' else _srv.local_address
+            s.connect(connect_to)
             self.tunnel_is_up[_srv.local_address] = _srv.tunnel_ok.get(
                 timeout=TUNNEL_TIMEOUT * 1.1
             )

--- a/tox.ini
+++ b/tox.ini
@@ -11,18 +11,16 @@
 #  and also to help confirm pull requests to this project.
 
 [tox]
-envlist = syntax, py{26,27,33,34,35,36}, docs
+envlist = syntax, py{27,33,34,35,36}, docs
 
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
     py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6
 deps =
-    py26: unittest2
     mock
     pytest
     pytest-cov
@@ -49,8 +47,7 @@ deps =
     {py27,py33,py34}: readme
 commands =
     check-manifest --ignore "tox.ini,tests*,*.yml"
-    # py26 doesn't have "setup.py check"
-    {py27,py33,py34}: python setup.py check -m -r -s
+    python setup.py check -m -r -s
     flake8 .
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -11,12 +11,11 @@
 #  and also to help confirm pull requests to this project.
 
 [tox]
-envlist = syntax, py{27,33,34,35,36}, docs
+envlist = syntax, py{27,34,35,36}, docs
 
 [testenv]
 basepython =
     py27: python2.7
-    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6
@@ -42,9 +41,11 @@ basepython = python
 skip_install = True
 deps =
     check-manifest
+    docutils
     flake8
     mccabe
-    {py27,py33,py34}: readme
+    pygments
+    readme
 commands =
     check-manifest --ignore "tox.ini,tests*,*.yml"
     python setup.py check -m -r -s

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@
 #  and also to help confirm pull requests to this project.
 
 [tox]
-envlist = syntax, py{26,27,33,34,35}, docs
+envlist = syntax, py{26,27,33,34,35,36}, docs
 
 [testenv]
 basepython =
@@ -20,6 +20,7 @@ basepython =
     py33: python3.3
     py34: python3.4
     py35: python3.5
+    py36: python3.6
 deps =
     py26: unittest2
     mock


### PR DESCRIPTION
Check if the address is `0.0.0.0` before switching it to `127.0.0.1`, else leave it as is. Add python 3.6 to tox.