### PR TITLE
Look for private keys on the host similar to Paramiko

### DIFF
--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -1004,8 +1004,9 @@ class SSHTunnelForwarder(object):
         Return:
             list
         """
-        keys = SSHTunnelForwarder.get_agent_keys(logger=logger) if \
-               allow_agent else []
+        keys = SSHTunnelForwarder.get_agent_keys(logger=logger) \
+            if allow_agent else []
+
         paramiko_key_types = {'rsa': paramiko.RSAKey,
                               'dsa': paramiko.DSSKey,
                               'ecdsa': paramiko.ECDSAKey,

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -988,7 +988,7 @@ class SSHTunnelForwarder(object):
         if logger:
             logger.info('{0} keys loaded from agent'.format(len(agent_keys)))
         return list(agent_keys)
-    
+
     @staticmethod
     def get_keys(logger=None, host_pkey_directories=None, allow_agent=False):
         """
@@ -1004,7 +1004,8 @@ class SSHTunnelForwarder(object):
         Return:
             list
         """
-        keys = self.get_agent_keys(logger=logger) if allow_agent else []
+        keys = SSHTunnelForwarder.get_agent_keys(logger=logger) if \
+               allow_agent else []
         paramiko_key_types = {'rsa': paramiko.RSAKey,
                               'dsa': paramiko.DSSKey,
                               'ecdsa': paramiko.ECDSAKey,

--- a/tests/test_forwarder.py
+++ b/tests/test_forwarder.py
@@ -17,6 +17,8 @@ from contextlib import contextmanager
 import mock
 import paramiko
 import sshtunnel
+import shutil
+import tempfile
 
 if sys.version_info[0] == 2:
     from cStringIO import StringIO
@@ -1174,6 +1176,23 @@ class SSHClientTest(unittest.TestCase):
             self.assertIsInstance(keys, list)
             self.assertTrue(any('0 keys loaded from agent' in l) for l in
                             self.sshtunnel_log_messages['info'])
+
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            shutil.copy(get_test_data_path(PKEY_FILE),
+                        os.path.join(tmp_dir, 'id_rsa'))
+
+            keys = sshtunnel.SSHTunnelForwarder.get_keys(
+                self.log,
+                host_directories=[tmp_dir, ]
+            )
+            self.assertIsInstance(keys, list)
+            self.assertTrue(
+                any('1 keys loaded from .ssh directory' in l)
+                for l in self.sshtunnel_log_messages['info']
+            )
+        finally:
+            shutil.rmtree(tmp_dir)
 
 
 class AuxiliaryTest(unittest.TestCase):


### PR DESCRIPTION
I've been using sshtunnel to implement/replace the current popen code used in Apache Airflow.
However, I noticed that sshtunnel wasn't picking up the id_rsa they used during testing. Hence, I've modified the get_keys method to also look for private keys there.

https://github.com/apache/incubator-airflow/pull/3473