### PR TITLE
Fix data loss occurring through the channel when the send buffer/wind…

### DIFF
--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -314,7 +314,7 @@ class _ForwardHandler(socketserver.BaseRequestHandler):
                                     self.remote_address,
                                     hexlify(data)
                                 ))
-                chan.send(data)
+                chan.sendall(data)
             if chan in rqst:  # else
                 if not chan.recv_ready():
                     break
@@ -323,7 +323,7 @@ class _ForwardHandler(socketserver.BaseRequestHandler):
                     TRACE_LEVEL,
                     '<<< IN {0} recv: {1} <<<'.format(self.info, hexlify(data))
                 )
-                self.request.send(data)
+                self.request.sendall(data)
 
     def handle(self):
         uid = get_connection_id()


### PR DESCRIPTION
…ow fills up.

This fix is not ideal. Since sendall() blocks until all data is sent, there may be a risk of a deadlock if there is data congestion in both directions simultaneously, depending on the behavior of the processes at both ends of the tunnel.  However, the likelihood is significantly lower than the likelihood of hitting the current bug where bytes are lost in the channel.  A better fix would be to select the channel and request for sending and send data in chunks within the same loop.  However, Paramiko channels currently do not support select for sending, which makes this approach more difficult.