### PR TITLE
Make SSH_TIMEOUT an overridable argument

### DIFF
--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -46,8 +46,6 @@ _DAEMON = False  #: Use daemon threads in connections
 TRACE_LEVEL = 1
 _CONNECTION_COUNTER = 1
 _LOCK = threading.Lock()
-#: Timeout (seconds) for the connection to the SSH gateway, ``None`` to disable
-SSH_TIMEOUT = None
 DEPRECATIONS = {
     'ssh_address': 'ssh_address_or_host',
     'ssh_host': 'ssh_address_or_host',
@@ -825,6 +823,7 @@ class SSHTunnelForwarder(object):
             mute_exceptions=False,
             remote_bind_address=None,
             remote_bind_addresses=None,
+            gateway_timeout=30,
             set_keepalive=0.0,
             threaded=True,  # old version False
             compression=None,
@@ -1113,7 +1112,7 @@ class SSHTunnelForwarder(object):
         else:
             _socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if isinstance(_socket, socket.socket):
-            _socket.settimeout(SSH_TIMEOUT)
+            _socket.settimeout(self.gateway_timeout)
             _socket.connect((self.ssh_host, self.ssh_port))
         transport = paramiko.Transport(_socket)
         transport.set_keepalive(self.set_keepalive)

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -642,6 +642,16 @@ class SSHTunnelForwarder(object):
 
             .. versionadded:: 0.0.8
 
+
+        gateway_timeout (float):
+            Time in seconds defining the period after which, if no tunnel
+            has been created, the connection attempt is stopped and a
+            :class:`BaseSSHTunnelForwarderError` is raised.
+
+            Default: 30.0 (gateway must be brought up within 30 seconds)
+
+            .. versionadded:: 0.1.3
+
         set_keepalive (float):
             Interval in seconds defining the period in which, if no data
             was sent over the connection, a *'keepalive'* packet will be
@@ -823,7 +833,7 @@ class SSHTunnelForwarder(object):
             mute_exceptions=False,
             remote_bind_address=None,
             remote_bind_addresses=None,
-            gateway_timeout=30,
+            gateway_timeout=30.0,
             set_keepalive=0.0,
             threaded=True,  # old version False
             compression=None,


### PR DESCRIPTION
Hello,

I'm working to integrate this awesome project into a project of mine, but kept running into an issue when testing connectivity to an SSH proxy server that was unreachable. In my tests, the tunnel connection took a full 120 seconds to time out and raise an exception. When I modified the original constant `SSH_TIMEOUT` to, say, 10, the session timed out after 10 seconds as was useful for my purposes.

In this PR I set a generous default timeout period of 30 seconds, but this could be adjusted if needed.

Thanks!