### PR TITLE
Major update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -195,7 +195,6 @@ time.
     with sshtunnel.open_tunnel(
         ssh_address_or_host=('GW1_ip', 20022),
         remote_bind_address=('GW2_ip', 22),
-        block_on_close=False
     ) as tunnel1:
         print('Connection to tunnel1 (GW1_ip:GW1_port) OK...')
         with sshtunnel.open_tunnel(
@@ -203,7 +202,6 @@ time.
             remote_bind_address=('target_ip', 22),
             ssh_username='GW2_user',
             ssh_password='GW2_pwd',
-            block_on_close=False
         ) as tunnel2:
             print('Connection to tunnel2 (GW2_ip:GW2_port) OK...')
             with SSHClient() as ssh:

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -1336,6 +1336,10 @@ class SSHTunnelForwarder(object):
             force (bool):
                 Force close current connections
 
+                Default: False
+
+                .. versionadded:: 0.2.2
+
         .. note:: This **had** to be handled with care before ``0.1.0``:
 
             - if a port redirection is opened
@@ -1590,7 +1594,7 @@ class SSHTunnelForwarder(object):
             self.__exit__()
 
     def __exit__(self, *args):
-        self._stop_transport()
+        self.stop(force=True)
 
 
 def open_tunnel(*args, **kwargs):
@@ -1613,12 +1617,6 @@ def open_tunnel(*args, **kwargs):
             Default: True
 
             .. versionadded:: 0.1.0
-
-        block_on_close (boolean):
-            Wait until all connections are done during close by changing the
-            value of :attr:`~SSHTunnelForwarder.block_on_close`
-
-            Default: True
 
     .. note::
         A value of ``debug_level`` set to 1 == ``TRACE`` enables tracing mode
@@ -1658,6 +1656,12 @@ def open_tunnel(*args, **kwargs):
     ssh_port = kwargs.pop('ssh_port', 22)
     skip_tunnel_checkup = kwargs.pop('skip_tunnel_checkup', True)
     block_on_close = kwargs.pop('block_on_close', _DAEMON)
+    if block_on_close:
+        warnings.warn("'block_on_close' is DEPRECATED. You should use either"
+                      " .stop() or .stop(force=True), depends on what you do"
+                      " with the active connections. This option has no"
+                      " affect since 0.3.0",
+                      DeprecationWarning)
     if not args:
         if isinstance(ssh_address_or_host, tuple):
             args = (ssh_address_or_host, )
@@ -1665,8 +1669,6 @@ def open_tunnel(*args, **kwargs):
             args = ((ssh_address_or_host, ssh_port), )
     forwarder = SSHTunnelForwarder(*args, **kwargs)
     forwarder.skip_tunnel_checkup = skip_tunnel_checkup
-    forwarder.daemon_forward_servers = not block_on_close
-    forwarder.daemon_transport = not block_on_close
     return forwarder
 
 


### PR DESCRIPTION
Currently `sshtunnel` uses hack with `daemon_forward_servers = True`. We are trying to use it for closing ssh tunnels without "deadlocks" / "tunneling hangs". This hack may cause unexpected behaviors in different python versions.

I think it's better to use a more predictable and less hackable way of closing an ssh transport first or waiting until all active connections to be closed (`.stop()` / `.stop(force=True)` behavior).

This change probably many not to be fully backward compatible.