### PR TITLE
Enable use of pathlib Paths for Python 3

### DIFF
--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -35,10 +35,11 @@ else:  # pragma: no cover
     string_types = str
     input_ = input
 
-path_types = string_types
-if sys.version_info[0] + sys.version_info[1] / 10 >= 3.4:
+if sys.version_info >= (3, 4):  # pragma: no cover
     from pathlib import Path
-    path_types = (string_types, Path)
+    path_types = (string_types, Path)  # Will need adjusting if Python 3 string_types becomes a tuple
+else:
+    path_types = string_types
 
 
 __version__ = '0.4.0'

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -28,16 +28,17 @@ if sys.version_info[0] < 3:  # pragma: no cover
     import Queue as queue
     import SocketServer as socketserver
     string_types = basestring,  # noqa
-    path_types = string_types
     input_ = raw_input  # noqa
 else:  # pragma: no cover
     import queue
     import socketserver
-    from pathlib import Path
     string_types = str
-    path_types = (string_types, Path)
     input_ = input
 
+path_types = string_types
+if sys.version_info[0] + sys.version_info[1] / 10 >= 3.4:
+    from pathlib import Path
+    path_types = (string_types, Path)
 
 
 __version__ = '0.4.0'


### PR DESCRIPTION
This will enable the usage of pathlib.Path objects for ssh_pkey for Python 3.4 and above.

Resolves #233 