### PR TITLE
Use destination port in proxy command from gitconfig

### DIFF
--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -1020,8 +1020,13 @@ class SSHTunnelForwarder(object):
             )
             ssh_host = hostname_info.get('hostname')
             ssh_port = ssh_port or hostname_info.get('port')
+            
+            if 'proxycommand' in hostname_info:
+                proxycommand = hostname_info.get('proxycommand')
+                config_port = hostname_info.get('port', "22")
+                if ssh_port != config_port:
+                    proxycommand = proxycommand.replace(config_port, ssh_port)
 
-            proxycommand = hostname_info.get('proxycommand')
             ssh_proxy = ssh_proxy or (paramiko.ProxyCommand(proxycommand) if
                                       proxycommand else None)
             if compression is None:


### PR DESCRIPTION
When reading a proxy command from the ssh config, the destination port is evaluated from the ssh config only.
With this change the destination port given to sshtunnel is combined with the proxy command.