### PR TITLE
Remove error message for PasswordRequiredException on SSH certificate

### DIFF
--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -1309,11 +1309,6 @@ class SSHTunnelForwarder(object):
                     logger.debug('Private key file ({0}, {1}) successfully '
                                  'loaded'.format(pkey_file, pkey_class))
                 break
-            except paramiko.PasswordRequiredException:
-                if logger:
-                    logger.error('Password is required for key {0}'
-                                 .format(pkey_file))
-                break
             except paramiko.SSHException:
                 if logger:
                     logger.debug('Private key file ({0}) could not be loaded '


### PR DESCRIPTION
## Issue
`PasswordRequiredException` was displaying even if a certificate was correctly loaded and de-encrypted in the SSH Agent,

**Scenario:** If you are using an ssh config file to configure hosts along with the ssh-agent, you should not need to explicitly pass a password for your certificate.

## Fix
I removed the catch as I expect `paramiko.SSHException` should gracefully handle any agent misconfiguration and paramiko's logging should make the issue clear.

The alternative would be to lower the log level for this message but I would expect this to be noisy for anyone in the above scenario.