### PR TITLE
Disable Nagle's algorithm on tunnel tcp socket (TCP_NODELAY)

### DIFF
--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -303,6 +303,7 @@ class _ForwardHandler(socketserver.BaseRequestHandler):
     info = None
 
     def _redirect(self, chan):
+        self.request.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         while chan.active:
             rqst, _, _ = select([self.request, chan], [], [], 5)
             if self.request in rqst:


### PR DESCRIPTION
Disable Nagle's algorithm on tunnel tcp socket to prevent stalls on chatty protocols (for example keepalive'd http requests).

Without this patch (2kb.dat is 2 KBytes of random data):
```
$ python3 ./sshtunnel.py -U user -P password -L :8081 -R 127.0.0.1:80 -p 22 host
$ time curl -s `for _ in {1..25}; do echo 'http://127.0.0.1:8081/2kb.dat -o /dev/null'; done`
real    0m0,948s
```
With this patch:
```
$ time curl -s `for _ in {1..25}; do echo 'http://127.0.0.1:8081/2kb.dat -o /dev/null'; done`
real    0m0,040s
```