### PR TITLE
Speedup bulk transfer

### DIFF
--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -313,14 +313,15 @@ class _ForwardHandler(socketserver.BaseRequestHandler):
                         '>>> OUT {0} recv empty data >>>'.format(self.info)
                     )
                     break
-                self.logger.log(
-                    TRACE_LEVEL,
-                    '>>> OUT {0} send to {1}: {2} >>>'.format(
-                        self.info,
-                        self.remote_address,
-                        hexlify(data)
+                if self.logger.isEnabledFor(TRACE_LEVEL):
+                    self.logger.log(
+                        TRACE_LEVEL,
+                        '>>> OUT {0} send to {1}: {2} >>>'.format(
+                            self.info,
+                            self.remote_address,
+                            hexlify(data)
+                        )
                     )
-                )
                 chan.sendall(data)
             if chan in rqst:  # else
                 if not chan.recv_ready():
@@ -330,10 +331,11 @@ class _ForwardHandler(socketserver.BaseRequestHandler):
                     )
                     break
                 data = chan.recv(16384)
-                self.logger.log(
-                    TRACE_LEVEL,
-                    '<<< IN {0} recv: {1} <<<'.format(self.info, hexlify(data))
-                )
+                if self.logger.isEnabledFor(TRACE_LEVEL):
+                    self.logger.log(
+                        TRACE_LEVEL,
+                        '<<< IN {0} recv: {1} <<<'.format(self.info, hexlify(data))
+                    )
                 self.request.sendall(data)
 
     def handle(self):

--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -306,7 +306,7 @@ class _ForwardHandler(socketserver.BaseRequestHandler):
         while chan.active:
             rqst, _, _ = select([self.request, chan], [], [], 5)
             if self.request in rqst:
-                data = self.request.recv(1024)
+                data = self.request.recv(16384)
                 if not data:
                     self.logger.log(
                         TRACE_LEVEL,
@@ -329,7 +329,7 @@ class _ForwardHandler(socketserver.BaseRequestHandler):
                         '<<< IN {0} recv is not ready <<<'.format(self.info)
                     )
                     break
-                data = chan.recv(1024)
+                data = chan.recv(16384)
                 self.logger.log(
                     TRACE_LEVEL,
                     '<<< IN {0} recv: {1} <<<'.format(self.info, hexlify(data))


### PR DESCRIPTION
This PR would greatly speedup bulk transfer:
- increase network buffer from 1kb to 16kb
- do not hexlify all transferred data in case the TRACE log level is disabled

Without these patches (1gb.dat is 1 GByte of random data):
```
$ python3 ./sshtunnel.py -U user -P password -L :8081 -R 127.0.0.1:80 -p 22 host
$ curl http://127.0.0.1:8081/1gb.dat -o /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1024M  100 1024M    0     0  10.0M      0  0:01:41  0:01:41 --:--:-- 10.2M
```
With increased network buffers:
```
$ curl http://127.0.0.1:8081/1gb.dat -o /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1024M  100 1024M    0     0  32.7M      0  0:00:31  0:00:31 --:--:-- 32.4M
```
With increased buffers and hexlify disabled:
```
$ curl http://127.0.0.1:8081/1gb.dat -o /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1024M  100 1024M    0     0  59.3M      0  0:00:17  0:00:17 --:--:-- 62.1M
```