### PR TITLE
Use custom logger in _ForwardServer

### DIFF
--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -383,7 +383,8 @@ class _ForwardServer(socketserver.TCPServer):  # Not Threading
     allow_reuse_address = True  # faster rebinding
 
     def __init__(self, *args, **kwargs):
-        self.logger = create_logger(kwargs.pop('logger', None))
+        logger = kwargs.pop('logger', None)
+        self.logger = logger or create_logger()
         self.tunnel_ok = queue.Queue(1)
         socketserver.TCPServer.__init__(self, *args, **kwargs)
 


### PR DESCRIPTION
It's problematic that we're doing `create_logger()` hidden in the `__init__` of `_ForwardServer` because it modifies the custom logger that we might be passing when creating an `SSHTunnelForwarder` by adding a console handler.
We do not always want a console handler.