### PR TITLE
Re-raise KeyboardInterrupt in __enter__

### DIFF
--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -1609,6 +1609,7 @@ class SSHTunnelForwarder(object):
             return self
         except KeyboardInterrupt:
             self.__exit__()
+            raise
 
     def __exit__(self, *args):
         self.stop(force=True)


### PR DESCRIPTION
Hi, thanks for your maintenance.

The function `SSHTunnelForwarder.__enter__` catch `KeyboardInterrupt` exception. The catch seems to exist in order to close tunnel, so the exception should be re-raised.

This PR changes the return type of `SSHTunnelForwarder.__enter__` from `SSHTunnelForwarder | None` to `SSHTunnelForwarder`.