### PR TITLE
Fixed empty ssh password case.

### DIFF
--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -1165,7 +1165,7 @@ class SSHTunnelForwarder(object):
         if isinstance(ssh_pkey, paramiko.pkey.PKey):
             ssh_loaded_pkeys.insert(0, ssh_pkey)
 
-        if not ssh_password and not ssh_loaded_pkeys:
+        if ssh_password is None and not ssh_loaded_pkeys:
             raise ValueError('No password or public key available!')
         return (ssh_password, ssh_loaded_pkeys)
 
@@ -1410,7 +1410,7 @@ class SSHTunnelForwarder(object):
                 self.logger.debug('Authentication error')
                 self._stop_transport()
 
-        if self.ssh_password:  # avoid conflict using both pass and pkey
+        if self.ssh_password is not None:  # avoid conflict using both pass and pkey
             self.logger.debug('Trying to log in with password: {0}'
                               .format('*' * len(self.ssh_password)))
             try:


### PR DESCRIPTION
fix: Changed if statements for ssh password to allow empty string

This pull request makes small but important improvements to the handling of `None` values in conditional checks for SSH password authentication in the `sshtunnel.py` file. These changes ensure more explicit comparisons, improving code clarity and reducing potential errors.

* **Improved conditional checks for `None`:**
  * In `_consolidate_auth`, updated the condition to explicitly check if `ssh_password` is `None` rather than relying on its falsy evaluation. This ensures clarity when distinguishing between `None` and other falsy values like an empty string.
  * In `_connect_to_gateway`, replaced the implicit truthiness check of `self.ssh_password` with an explicit comparison to `None`, making the intent clearer and avoiding ambiguity.