### PR TITLE
Resolve SIM107 in sshtunnel.py

### DIFF
--- a/sshtunnel.py
+++ b/sshtunnel.py
@@ -1036,13 +1036,13 @@ class SSHTunnelForwarder(object):
         except (AttributeError, TypeError):  # ssh_config_file is None
             if logger:
                 logger.info('Skipping loading of ssh configuration file')
-        finally:
-            return (ssh_host,
-                    ssh_username or getpass.getuser(),
-                    ssh_pkey,
-                    int(ssh_port) if ssh_port else 22,  # fallback value
-                    ssh_proxy,
-                    compression)
+
+        return (ssh_host,
+                ssh_username or getpass.getuser(),
+                ssh_pkey,
+                int(ssh_port) if ssh_port else 22,  # fallback value
+                ssh_proxy,
+                compression)
 
     @staticmethod
     def get_agent_keys(logger=None):


### PR DESCRIPTION
As per [PEP 765](https://peps.python.org/pep-0765/), Python 3.14 now emits `SyntaxWarning: 'return' in a 'finally' block` when return is used in a finally block.

Closes #308 